### PR TITLE
:green_heart: add libraries to conda runtime requirements

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -25,6 +25,11 @@ requirements:
     - blas
 
   run:
+    - libgcc-ng # [linux]
+    - libstdcxx-ng # [linux]
+    - gsl
+    - hdf5
+    - zlib
     - python
     - notebook
     - ffmpeg # [osx]


### PR DESCRIPTION
This PR suppresses some of the warnings while linking.