### PR TITLE
:rotating_light: suppress warnings while compilation

### DIFF
--- a/ecell4/egfrd/EGFRDSimulator.hpp
+++ b/ecell4/egfrd/EGFRDSimulator.hpp
@@ -3904,6 +3904,7 @@ protected:
         case PAIR_EVENT_IV_REACTION:
             return "iv_reaction";
         }
+        throw illegal_state("EGFRDSimulator::stringize_event_kind: never get here");
     }
 
     static std::string stringize_event(single_event const& ev)
@@ -4100,6 +4101,7 @@ protected:
         }
 
         BOOST_ASSERT(false); // should never happen
+        throw illegal_state("EGFRDSimulator::draw_reaction_rule: should never happen");
     }
 
     //template<typename T1, typename T2>

--- a/ecell4/egfrd/egfrd.hpp
+++ b/ecell4/egfrd/egfrd.hpp
@@ -114,7 +114,7 @@ protected:
     }
 
     virtual simulator_type* create_simulator(
-        const boost::shared_ptr<world_type>& w, const boost::shared_ptr<Model>& m) const
+        const boost::shared_ptr<world_type>& w, const boost::shared_ptr<Model>& m) const override
     {
         if (user_max_shell_size_ != default_user_max_shell_size())
         {


### PR DESCRIPTION
It just suppresses compiler's warnings.

- throw `illegal_state` when control reaches to the unexpected place
- add `override` specifier