### PR TITLE
:construction_worker: use both conda 36 and 37 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ platform:
 environment:
   matrix:
   - CONDA: 36-x64
-  #- CONDA: 37-x64
+  - CONDA: 37-x64
 
 init:
 - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"


### PR DESCRIPTION
It seems that now `CONDA: 37-x64` works on Appveyor.