### PR TITLE
:bug: check bound model before adding molecules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 env:
   - PYTHON_VERSION=3.6
-  - PYTHON_VERSION=3.7
+  - PYTHON_VERSION=3.7.3
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget -O miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh; fi

--- a/ecell4/sgfrd/SGFRDWorld.cpp
+++ b/ecell4/sgfrd/SGFRDWorld.cpp
@@ -45,8 +45,10 @@ SGFRDWorld::new_particle(const Particle& p, const FaceID& fid)
 }
 
 std::pair<std::pair<ParticleID, Particle>, bool>
-SGFRDWorld::throw_in_particle(const Species& sp)
+SGFRDWorld::throw_in_particle(const Species& sp_)
 {
+    const auto model = this->lock_model();
+    const auto sp = model->apply_species_attributes(sp_);
     const Real r = sp.get_attribute_as<Real>("radius");
     const Real D = sp.get_attribute_as<Real>("D");
 
@@ -72,7 +74,7 @@ void SGFRDWorld::add_molecules(const Species& sp, const Integer& num)
     return;
 }
 
-void SGFRDWorld::add_molecules(const Species& sp, const Integer& num,
+void SGFRDWorld::add_molecules(const Species& sp_, const Integer& num,
                                const boost::shared_ptr<Shape> shape)
 {
     if (num < 0)
@@ -161,6 +163,8 @@ void SGFRDWorld::add_molecules(const Species& sp, const Integer& num,
         throw std::invalid_argument("The shape does not overlap with polygon.");
     }
 
+    const auto model = this->lock_model();
+    const auto sp = model->apply_species_attributes(sp_);
     const Real r = sp.get_attribute_as<Real>("radius");
     const Real D = sp.get_attribute_as<Real>("D");
     for(Integer i=0; i<num; ++i)

--- a/ecell4/sgfrd/SGFRDWorld.hpp
+++ b/ecell4/sgfrd/SGFRDWorld.hpp
@@ -341,15 +341,19 @@ class SGFRDWorld
     new_particle(const Particle& p, const FaceID& fid);
 
     std::pair<std::pair<ParticleID, Particle>, bool>
-    new_particle(const Species& sp, const Real3& pos)
+    new_particle(const Species& sp_, const Real3& pos)
     {
+        const auto model = this->lock_model();
+        const auto sp = model->apply_species_attributes(sp_);
         const Real r = sp.get_attribute_as<Real>("radius");
         const Real D = sp.get_attribute_as<Real>("D");
         return this->new_particle(Particle(sp, pos, r, D));
     }
     std::pair<std::pair<ParticleID, Particle>, bool>
-    new_particle(const Species& sp, const FaceID& fid, const Barycentric& bary)
+    new_particle(const Species& sp_, const FaceID& fid, const Barycentric& bary)
     {
+        const auto model = this->lock_model();
+        const auto sp = model->apply_species_attributes(sp_);
         const auto r = sp.get_attribute_as<Real>("radius");
         const auto D = sp.get_attribute_as<Real>("D");
 


### PR DESCRIPTION
Since world.add_molecules() often receives a Species that only has its
serial, some indispensable parameters such taht `radius` and `D` might
be missing. To avoid this inconvenience, it is needed to search species
in the model that is bound to the world.