### PR TITLE
:bug: never assume Species has attributes

### DIFF
--- a/ecell4/sgfrd/BDPropagator.hpp
+++ b/ecell4/sgfrd/BDPropagator.hpp
@@ -305,8 +305,9 @@ public:
         SGFRD_SCOPE(ns, BD_attempt_1to1_reaction, this->vc_.access_tracer())
         const species_type species_new =
             this->model_.apply_species_attributes(rlog.first.products().front());
-        const Real radius_new = species_new.get_attribute_as<Real>("radius");
-        const Real D_new      = species_new.get_attribute_as<Real>("D");
+        const auto molinfo    = container_.get_molecule_info(species_new);
+        const Real radius_new = molinfo.radius;
+        const Real D_new      = molinfo.D;
 
         if(is_overlapping(std::make_pair(p.position(), fid), radius_new, pid))
         {
@@ -349,12 +350,14 @@ public:
             model_.apply_species_attributes(rlog.first.products().at(0));
         const Species sp2 =
             model_.apply_species_attributes(rlog.first.products().at(1));
+        const auto molinfo1 = container_.get_molecule_info(sp1);
+        const auto molinfo2 = container_.get_molecule_info(sp2);
 
-        const Real D1  = sp1.get_attribute_as<Real>("D");
-        const Real D2  = sp2.get_attribute_as<Real>("D");
+        const Real D1  = molinfo1.D;
+        const Real D2  = molinfo2.D;
+        const Real r1  = molinfo1.radius;
+        const Real r2  = molinfo2.radius;
         const Real D12 = D1 + D2;
-        const Real r1  = sp1.get_attribute_as<Real>("radius");
-        const Real r2  = sp2.get_attribute_as<Real>("radius");
         const Real r12 = r1 + r2;
 
         if(D1 == 0. && D2 == 0)
@@ -505,8 +508,9 @@ public:
             reaction_log_type rlog)
     {
         const species_type sp_new(rlog.first.products().front());
-        const Real radius_new = sp_new.get_attribute_as<Real>("radius");
-        const Real D_new      = sp_new.get_attribute_as<Real>("D");
+        const auto molinfo = this->container_.get_molecule_info(sp_new);
+        const Real radius_new = molinfo.radius;
+        const Real D_new      = molinfo.D;
 
         const Real3 pos1(p1.position()), pos2(p2.position());
         const Real D1(p1.D()), D2(p2.D());

--- a/ecell4/sgfrd/BDPropagator.hpp
+++ b/ecell4/sgfrd/BDPropagator.hpp
@@ -303,11 +303,10 @@ public:
             reaction_log_type rlog)
     {
         SGFRD_SCOPE(ns, BD_attempt_1to1_reaction, this->vc_.access_tracer())
-        const species_type species_new =
-            this->model_.apply_species_attributes(rlog.first.products().front());
-        const auto molinfo    = container_.get_molecule_info(species_new);
-        const Real radius_new = molinfo.radius;
-        const Real D_new      = molinfo.D;
+        const auto species_new = rlog.first.products().front();
+        const auto molinfo     = container_.get_molecule_info(species_new);
+        const Real radius_new  = molinfo.radius;
+        const Real D_new       = molinfo.D;
 
         if(is_overlapping(std::make_pair(p.position(), fid), radius_new, pid))
         {
@@ -346,10 +345,8 @@ public:
     {
         SGFRD_SCOPE(ns, BD_attempt_1to2_reaction, this->vc_.access_tracer())
 
-        const Species sp1 =
-            model_.apply_species_attributes(rlog.first.products().at(0));
-        const Species sp2 =
-            model_.apply_species_attributes(rlog.first.products().at(1));
+        const auto sp1      = rlog.first.products().at(0);
+        const auto sp2      = rlog.first.products().at(1);
         const auto molinfo1 = container_.get_molecule_info(sp1);
         const auto molinfo2 = container_.get_molecule_info(sp2);
 

--- a/ecell4/sgfrd/MultiContainer.hpp
+++ b/ecell4/sgfrd/MultiContainer.hpp
@@ -19,6 +19,7 @@ class MultiContainer
     typedef world_type::structure_registrator_type structure_registrator_type;
     typedef world_type::particle_space_type        particle_space_type;
     typedef world_type::particle_container_type    particle_container_type;
+    typedef world_type::molecule_info_type         molecule_info_type;
 
   public:
 
@@ -230,6 +231,11 @@ class MultiContainer
     std::pair<ParticleID, Particle> get_particle(const ParticleID& pid) const
     {
         return this->world_.get_particle(pid);
+    }
+
+    MoleculeInfo get_molecule_info(const Species& sp) const
+    {
+        return world_.get_molecule_info(sp);
     }
 
   private:

--- a/ecell4/sgfrd/SGFRDSimulator.cpp
+++ b/ecell4/sgfrd/SGFRDSimulator.cpp
@@ -188,10 +188,12 @@ SGFRDSimulator::attempt_reaction_1_to_1(const ReactionRule& rule,
 {
     SGFRD_SCOPE(us, attempt_reaction_1_to_1, tracer_)
 
-    const Species species_new =
-        this->model_->apply_species_attributes(rule.products().front());
-    const Real radius_new = species_new.get_attribute_as<Real>("radius");
-    const Real D_new      = species_new.get_attribute_as<Real>("D");
+    const auto species_new = this->model_->apply_species_attributes(
+                                rule.products().front());
+    const auto molinfo     = this->world_->get_molecule_info(species_new);
+    const Real radius_new  = molinfo.radius;
+    const Real D_new       = molinfo.D;
+
     const Particle p_new(species_new, p.position(), radius_new, D_new);
 
     inside_checker is_inside_of(
@@ -234,11 +236,14 @@ SGFRDSimulator::attempt_reaction_1_to_2(const ReactionRule& rule,
     const Species sp2 =
         this->model_->apply_species_attributes(rule.products().at(1));
 
-    const Real D1 = sp1.get_attribute_as<Real>("D");
-    const Real D2 = sp2.get_attribute_as<Real>("D");
+    const auto molinfo1 = this->world_->get_molecule_info(sp1);
+    const auto molinfo2 = this->world_->get_molecule_info(sp2);
+
+    const Real D1 = molinfo1.D;
+    const Real D2 = molinfo2.D;
 //     const Real D12 = D1 + D2
-    const Real r1 = sp1.get_attribute_as<Real>("radius");
-    const Real r2 = sp2.get_attribute_as<Real>("radius");
+    const Real r1 = molinfo1.radius;
+    const Real r2 = molinfo2.radius;
     const Real r12 = r1 + r2;
 
     SGFRD_TRACE(tracer_.write("products has D1(%1%), D2(%2%), r1(%3%), r2(%4%)",

--- a/ecell4/sgfrd/SGFRDSimulator.cpp
+++ b/ecell4/sgfrd/SGFRDSimulator.cpp
@@ -188,8 +188,7 @@ SGFRDSimulator::attempt_reaction_1_to_1(const ReactionRule& rule,
 {
     SGFRD_SCOPE(us, attempt_reaction_1_to_1, tracer_)
 
-    const auto species_new = this->model_->apply_species_attributes(
-                                rule.products().front());
+    const auto species_new = rule.products().front();
     const auto molinfo     = this->world_->get_molecule_info(species_new);
     const Real radius_new  = molinfo.radius;
     const Real D_new       = molinfo.D;
@@ -231,10 +230,8 @@ SGFRDSimulator::attempt_reaction_1_to_2(const ReactionRule& rule,
 {
     SGFRD_SCOPE(us, attempt_reaction_1_to_2, tracer_)
 
-    const Species sp1 =
-        this->model_->apply_species_attributes(rule.products().at(0));
-    const Species sp2 =
-        this->model_->apply_species_attributes(rule.products().at(1));
+    const auto sp1 = rule.products().at(0);
+    const auto sp2 = rule.products().at(1);
 
     const auto molinfo1 = this->world_->get_molecule_info(sp1);
     const auto molinfo2 = this->world_->get_molecule_info(sp2);

--- a/ecell4/sgfrd/SGFRDSimulator.hpp
+++ b/ecell4/sgfrd/SGFRDSimulator.hpp
@@ -1215,10 +1215,11 @@ class SGFRDSimulator :
                 const FaceID fid_new = pos_com.second;
 
                 // make new particle
-                const Species species_new =
-                    this->model_->apply_species_attributes(rule.products().front());
-                const Real radius_new = species_new.get_attribute_as<Real>("radius");
-                const Real D_new      = species_new.get_attribute_as<Real>("D");
+                const auto species_new = this->model_->apply_species_attributes(
+                                             rule.products().front());
+                const auto molinfo     = this->world_->get_molecule_info(species_new);
+                const Real radius_new  = molinfo.radius;
+                const Real D_new       = molinfo.D;
                 const Particle p_new(species_new, pos_new, radius_new, D_new);
 
                 inside_checker is_inside_of(

--- a/ecell4/sgfrd/SGFRDSimulator.hpp
+++ b/ecell4/sgfrd/SGFRDSimulator.hpp
@@ -1215,8 +1215,7 @@ class SGFRDSimulator :
                 const FaceID fid_new = pos_com.second;
 
                 // make new particle
-                const auto species_new = this->model_->apply_species_attributes(
-                                             rule.products().front());
+                const auto species_new = rule.products().front();
                 const auto molinfo     = this->world_->get_molecule_info(species_new);
                 const Real radius_new  = molinfo.radius;
                 const Real D_new       = molinfo.D;


### PR DESCRIPTION
It looks a bit weird, but it sometimes crashes when it tries to get an attribute from species that is returned from `model.apply_species_attributes` when we call them from python.