### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,7 +12,7 @@ jobs:
     - name: submodule
       run: git submodule init && git submodule update
     - name: deps
-      run: apt-get update && sudo apt-get install -y wget bzip2 python3-pip libgsl-dev libboost-dev cmake && python3 -m pip install -U pip setuptools
+      run: sudo apt-get update && sudo apt-get install -y wget bzip2 python3-pip libgsl-dev libboost-dev cmake && sudo python3 -m pip install -U pip setuptools
     - name: hdf5
       run: wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2 && tar xf hdf5-1.10.4.tar.bz2 && cd hdf5-1.10.4 && ./configure --enable-cxx --prefix=/opt/hdf5 && make && sudo make install && cd ..
     - name: export

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -15,11 +15,38 @@ jobs:
     - name: deps
       run: |
         sudo apt-get update
-        sudo apt-get install -y wget bzip2 python3-pip libhdf5-dev libgsl-dev libboost-dev cmake
+        sudo apt-get install -y wget bzip2 python3-pip libgsl-dev libboost-dev cmake
         sudo python3 -m pip install -U pip setuptools
+
+    - name: Download hdf5
+      run: wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2
+
+    - name: Cache hdf5
+      id: cache-hdf5
+      uses: actions/cache@v1
+      with:
+        path: hdf5-1.10.4
+        key: ${{ runner.OS }}-build-${{ hashFiles('hdf5-1.10.4.tar.bz2') }}
+
+    - name: Build hdf5
+      if: steps.cache-hdf5.outputs.cache-hit != 'true'
+      run: |
+        tar xf hdf5-1.10.4.tar.bz2
+        cd hdf5-1.10.4
+        ./configure --enable-cxx --prefix=/opt/hdf5
+        make
+        cd ..
+
+    - name: Install hdf5
+      run: cd hdf5-1.10.4 && sudo make install && cd ..
 
     - name: setuppy
       run: |
+        export PATH=/opt/hdf5/bin:${PATH}
+        export LIBRARY_PATH=/opt/hdf5/lib:${LIBRARY_PATH}
+        export LD_LIBRARY_PATH=/opt/hdf5/lib:${LD_LIBRARY_PATH}
+        export LD_RUN_PATH=/opt/hdf5/lib:${LD_RUN_PATH}
+        export INCLUDE_PATH=/opt/hdf5/include:${INCLUDE_PATH}
         python3 setup.py build
         python3 setup.py test
         sudo python3 setup.py install

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         tar xf hdf5-1.10.4.tar.bz2
         cd hdf5-1.10.4
-        ./configure --enable-cxx --prefix=/usr/local
+        ./configure --enable-cxx --prefix=/opt/hdf5
         make
         cd ..
 
@@ -45,6 +45,8 @@ jobs:
 
     - name: setuppy
       run: |
+        export HDF5_ROOT=/opt/hdf5
+        export LD_LIBRARY_PATH=/opt/hdf5/lib
         python3 setup.py build
         python3 setup.py test
         sudo python3 setup.py install

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -8,18 +8,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v1
-      with:
-        submodules: true
-
+    - uses: actions/checkout@v1
+    - name: submodule
+      run: git submodule init && git submodule update
     - name: deps
       run: sudo apt-get update && sudo apt-get install -y wget bzip2 python3-pip libgsl-dev libboost-dev cmake && sudo python3 -m pip install -U pip setuptools
-
     - name: hdf5
-      run: wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2 && tar xf hdf5-1.10.4.tar.bz2 && cd hdf5-1.10.4 && ./configure --enable-cxx && make && sudo make install && cd ..
-
+      run: wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2 && tar xf hdf5-1.10.4.tar.bz2 && cd hdf5-1.10.4 && ./configure --enable-cxx --prefix=/opt/hdf5 && make && sudo make install && cd ..
     - name: setuppy
       run: python3 setup.py build && sudo python3 setup.py install && sudo python3 setup.py test
+      env:
+        PATH: /opt/hdf5/bin:${PATH}
+        LD_LIBRARY_PATH: /opt/hdf5/lib:${LD_LIBRARY_PATH}
+        LIBRARY_PATH: /opt/hdf5/lib:${LIBRARY_PATH}
+        LD_RN_PATH: /opt/hdf5/lib:${LD_RUN_PATH}
+        INCLUDE_PATH: /opt/hdf5/include:${INCLUDE_PATH}
     - name: hoge
       run: pwd

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         tar xf hdf5-1.10.4.tar.bz2
         cd hdf5-1.10.4
-        ./configure --enable-cxx
+        ./configure --enable-cxx --prefix=/usr/local
         make
         cd ..
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -8,9 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: submodule
-      run: git submodule init && git submodule update
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        submodules: true
     - name: deps
       run: sudo apt-get update && sudo apt-get install -y wget bzip2 python3-pip libgsl-dev libboost-dev cmake && sudo python3 -m pip install -U pip setuptools
     - name: hdf5
@@ -25,5 +26,5 @@ jobs:
         python3 setup.py build
         python3 setup.py test
         sudo python3 setup.py install
-    - name: hoge
-      run: pwd
+    - name: import_test
+      run: python3 -c "from ecell4_base import core"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -8,20 +8,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: submodule
-      run: git submodule init && git submodule update
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        submodules: true
+
     - name: deps
       run: sudo apt-get update && sudo apt-get install -y wget bzip2 python3-pip libgsl-dev libboost-dev cmake && sudo python3 -m pip install -U pip setuptools
+
     - name: hdf5
-      run: wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2 && tar xf hdf5-1.10.4.tar.bz2 && cd hdf5-1.10.4 && ./configure --enable-cxx --prefix=/opt/hdf5 && make && sudo make install && cd ..
+      run: wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2 && tar xf hdf5-1.10.4.tar.bz2 && cd hdf5-1.10.4 && ./configure --enable-cxx && make && sudo make install && cd ..
+
     - name: setuppy
       run: python3 setup.py build && sudo python3 setup.py install && sudo python3 setup.py test
-      env:
-        PATH: /opt/hdf5/bin:${PATH}
-        LD_LIBRARY_PATH: /opt/hdf5/lib:${LD_LIBRARY_PATH}
-        LIBRARY_PATH: /opt/hdf5/lib:${LIBRARY_PATH}
-        LD_RN_PATH: /opt/hdf5/lib:${LD_RUN_PATH}
-        INCLUDE_PATH: /opt/hdf5/include:${INCLUDE_PATH}
     - name: hoge
       run: pwd

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         tar xf hdf5-1.10.4.tar.bz2
         cd hdf5-1.10.4
-        ./configure --enable-cxx --prefix=/opt/hdf5
+        ./configure --enable-cxx
         make
         cd ..
 
@@ -42,11 +42,6 @@ jobs:
 
     - name: setuppy
       run: |
-        export PATH=/opt/hdf5/bin:${PATH}
-        export LIBRARY_PATH=/opt/hdf5/lib:${LIBRARY_PATH}
-        export LD_LIBRARY_PATH=/opt/hdf5/lib:${LD_LIBRARY_PATH}
-        export LD_RUN_PATH=/opt/hdf5/lib:${LD_RUN_PATH}
-        export INCLUDE_PATH=/opt/hdf5/include:${INCLUDE_PATH}
         python3 setup.py build
         python3 setup.py test
         sudo python3 setup.py install

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -52,4 +52,6 @@ jobs:
         sudo python3 setup.py install
 
     - name: import_test
-      run: python3 -c "from ecell4_base import core"
+      run: |
+        export LD_LIBRARY_PATH=/opt/hdf5/lib
+        python3 -c "from ecell4_base import core"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -16,12 +16,14 @@ jobs:
     - name: hdf5
       run: wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2 && tar xf hdf5-1.10.4.tar.bz2 && cd hdf5-1.10.4 && ./configure --enable-cxx --prefix=/opt/hdf5 && make && sudo make install && cd ..
     - name: setuppy
-      run: python3 setup.py build && sudo python3 setup.py install && sudo python3 setup.py test
-      env:
-        PATH: /opt/hdf5/bin:${PATH}
-        LD_LIBRARY_PATH: /opt/hdf5/lib:${LD_LIBRARY_PATH}
-        LIBRARY_PATH: /opt/hdf5/lib:${LIBRARY_PATH}
-        LD_RN_PATH: /opt/hdf5/lib:${LD_RUN_PATH}
-        INCLUDE_PATH: /opt/hdf5/include:${INCLUDE_PATH}
+      run: |
+        export PATH=/opt/hdf5/bin:${PATH}
+        export LIBRARY_PATH=/opt/hdf5/lib:${LIBRARY_PATH}
+        export LD_LIBRARY_PATH=/opt/hdf5/lib:${LD_LIBRARY_PATH}
+        export LD_RUN_PATH=/opt/hdf5/lib:${LD_RUN_PATH}
+        export INCLUDE_PATH=/opt/hdf5/include:${INCLUDE_PATH}
+        python3 setup.py build
+        python3 setup.py test
+        sudo python3 setup.py install
     - name: hoge
       run: pwd

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,22 @@
+name: C/C++ CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: submodule
+      run: git submodule init && git submodule update
+    - name: deps
+      run: apt-get update && sudo apt-get install -y wget bzip2 python3-pip libgsl-dev libboost-dev cmake && python3 -m pip install -U pip setuptools
+    - name: hdf5
+      run: wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2 && tar xf hdf5-1.10.4.tar.bz2 && cd hdf5-1.10.4 && ./configure --enable-cxx --prefix=/opt/hdf5 && make && sudo make install && cd ..
+    - name: export
+      run: export PATH=/opt/hdf5/bin:${PATH} && export LD_LIBRARY_PATH=/opt/hdf5/lib:${LD_LIBRARY_PATH} && export LIBRARY_PATH=/opt/hdf5/lib:${LIBRARY_PATH} && export LD_RUN_PATH=/opt/hdf5/lib:${LD_RUN_PATH} && export INCLUDE_PATH=/opt/hdf5/include:${INCLUDE_PATH}
+    - name: setuppy
+      run: python3 setup.py build && sudo python3 setup.py install && sudo python3 setup.py test
+      

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -4,18 +4,29 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout
       uses: actions/checkout@v1
       with:
         submodules: true
+
     - name: deps
-      run: sudo apt-get update && sudo apt-get install -y wget bzip2 python3-pip libgsl-dev libboost-dev cmake && sudo python3 -m pip install -U pip setuptools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y wget bzip2 python3-pip libgsl-dev libboost-dev cmake
+        sudo python3 -m pip install -U pip setuptools
+
     - name: hdf5
-      run: wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2 && tar xf hdf5-1.10.4.tar.bz2 && cd hdf5-1.10.4 && ./configure --enable-cxx --prefix=/opt/hdf5 && make && sudo make install && cd ..
+      run: |
+        wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2
+        tar xf hdf5-1.10.4.tar.bz2
+        cd hdf5-1.10.4
+        ./configure --enable-cxx --prefix=/opt/hdf5
+        make
+        sudo make install
+        cd ..
+
     - name: setuppy
       run: |
         export PATH=/opt/hdf5/bin:${PATH}
@@ -26,5 +37,6 @@ jobs:
         python3 setup.py build
         python3 setup.py test
         sudo python3 setup.py install
+
     - name: import_test
       run: python3 -c "from ecell4_base import core"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -52,3 +52,21 @@ jobs:
       run: |
         export LD_LIBRARY_PATH=/opt/hdf5/lib
         python3 -c "from ecell4_base import core"
+
+  build-for-macos:
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Install dependencies
+      run: brew update && brew install boost gsl hdf5 cmake python
+
+    - name: Build and Install ecell4_base
+      run: /usr/local/bin/python3 setup.py install
+
+    - name: Test ecell4_base
+      run: /usr/local/bin/python3 setup.py test

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -18,9 +18,6 @@ jobs:
         sudo apt-get install -y wget bzip2 python3-pip libgsl-dev libboost-dev cmake
         sudo python3 -m pip install -U pip setuptools
 
-    - name: echo PATH
-      run: echo "$PATH"
-
     - name: Download hdf5
       run: wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -6,7 +6,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v1
     - name: submodule
@@ -15,9 +15,13 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y wget bzip2 python3-pip libgsl-dev libboost-dev cmake && sudo python3 -m pip install -U pip setuptools
     - name: hdf5
       run: wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2 && tar xf hdf5-1.10.4.tar.bz2 && cd hdf5-1.10.4 && ./configure --enable-cxx --prefix=/opt/hdf5 && make && sudo make install && cd ..
-    - name: export
-      run: export PATH=/opt/hdf5/bin:${PATH} && export LD_LIBRARY_PATH=/opt/hdf5/lib:${LD_LIBRARY_PATH} && export LIBRARY_PATH=/opt/hdf5/lib:${LIBRARY_PATH} && export LD_RUN_PATH=/opt/hdf5/lib:${LD_RUN_PATH} && export INCLUDE_PATH=/opt/hdf5/include:${INCLUDE_PATH}
     - name: setuppy
       run: python3 setup.py build && sudo python3 setup.py install && sudo python3 setup.py test
+      env:
+        PATH: /opt/hdf5/bin:${PATH}
+        LD_LIBRARY_PATH: /opt/hdf5/lib:${LD_LIBRARY_PATH}
+        LIBRARY_PATH: /opt/hdf5/lib:${LIBRARY_PATH}
+        LD_RN_PATH: /opt/hdf5/lib:${LD_RUN_PATH}
+        INCLUDE_PATH: /opt/hdf5/include:${INCLUDE_PATH}
     - name: hoge
-      run: pwd      
+      run: pwd

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -15,38 +15,11 @@ jobs:
     - name: deps
       run: |
         sudo apt-get update
-        sudo apt-get install -y wget bzip2 python3-pip libgsl-dev libboost-dev cmake
+        sudo apt-get install -y wget bzip2 python3-pip libhdf5-dev libgsl-dev libboost-dev cmake
         sudo python3 -m pip install -U pip setuptools
-
-    - name: Download hdf5
-      run: wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2
-
-    - name: Cache hdf5
-      id: cache-hdf5
-      uses: actions/cache@v1
-      with:
-        path: hdf5-1.10.4
-        key: ${{ runner.OS }}-build-${{ hashFiles('hdf5-1.10.4.tar.bz2') }}
-
-    - name: Build hdf5
-      if: steps.cache-hdf5.outputs.cache-hit != 'true'
-      run: |
-        tar xf hdf5-1.10.4.tar.bz2
-        cd hdf5-1.10.4
-        ./configure --enable-cxx --prefix=/opt/hdf5
-        make
-        cd ..
-
-    - name: Install hdf5
-      run: cd hdf5-1.10.4 && sudo make install && cd ..
 
     - name: setuppy
       run: |
-        export PATH=/opt/hdf5/bin:${PATH}
-        export LIBRARY_PATH=/opt/hdf5/lib:${LIBRARY_PATH}
-        export LD_LIBRARY_PATH=/opt/hdf5/lib:${LD_LIBRARY_PATH}
-        export LD_RUN_PATH=/opt/hdf5/lib:${LD_RUN_PATH}
-        export INCLUDE_PATH=/opt/hdf5/include:${INCLUDE_PATH}
         python3 setup.py build
         python3 setup.py test
         python3 setup.py install

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -17,9 +17,19 @@ jobs:
         sudo apt-get install -y wget bzip2 python3-pip libgsl-dev libboost-dev cmake
         sudo python3 -m pip install -U pip setuptools
 
-    - name: hdf5
+    - name: Download hdf5
+      run: wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2
+
+    - name: Cache hdf5
+      id: cache-hdf5
+      uses: actions/cache@v1
+      with:
+        path: hdf5-1.10.4
+        key: ${{ runner.OS }}-build-${{ hashFiles('hdf5-1.10.4.tar.bz2') }}
+
+    - name: Build and Install hdf5
+      if: steps.cache-hdf5.outputs.cache-hit != 'true'
       run: |
-        wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2
         tar xf hdf5-1.10.4.tar.bz2
         cd hdf5-1.10.4
         ./configure --enable-cxx --prefix=/opt/hdf5

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -18,6 +18,9 @@ jobs:
         sudo apt-get install -y wget bzip2 python3-pip libgsl-dev libboost-dev cmake
         sudo python3 -m pip install -U pip setuptools
 
+    - name: echo PATH
+      run: echo "$PATH"
+
     - name: Download hdf5
       run: wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         python3 setup.py build
         python3 setup.py test
-        python3 setup.py install
+        sudo python3 setup.py install
 
     - name: import_test
       run: python3 -c "from ecell4_base import core"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -19,4 +19,5 @@ jobs:
       run: export PATH=/opt/hdf5/bin:${PATH} && export LD_LIBRARY_PATH=/opt/hdf5/lib:${LD_LIBRARY_PATH} && export LIBRARY_PATH=/opt/hdf5/lib:${LIBRARY_PATH} && export LD_RUN_PATH=/opt/hdf5/lib:${LD_RUN_PATH} && export INCLUDE_PATH=/opt/hdf5/include:${INCLUDE_PATH}
     - name: setuppy
       run: python3 setup.py build && sudo python3 setup.py install && sudo python3 setup.py test
-      
+    - name: hoge
+      run: pwd      

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -49,7 +49,7 @@ jobs:
         export INCLUDE_PATH=/opt/hdf5/include:${INCLUDE_PATH}
         python3 setup.py build
         python3 setup.py test
-        sudo python3 setup.py install
+        python3 setup.py install
 
     - name: import_test
       run: python3 -c "from ecell4_base import core"

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
     - name: Checkout
       uses: actions/checkout@v1
@@ -27,15 +28,17 @@ jobs:
         path: hdf5-1.10.4
         key: ${{ runner.OS }}-build-${{ hashFiles('hdf5-1.10.4.tar.bz2') }}
 
-    - name: Build and Install hdf5
+    - name: Build hdf5
       if: steps.cache-hdf5.outputs.cache-hit != 'true'
       run: |
         tar xf hdf5-1.10.4.tar.bz2
         cd hdf5-1.10.4
         ./configure --enable-cxx --prefix=/opt/hdf5
         make
-        sudo make install
         cd ..
+
+    - name: Install hdf5
+      run: cd hdf5-1.10.4 && sudo make install && cd ..
 
     - name: setuppy
       run: |


### PR DESCRIPTION
Enable CI tests for `Ubuntu` and `macOS` on Github Actions.
This may replace CI tests on Azure Pipelines.