### PR TITLE
:green_heart: Enforce to run 'brew upgrade' on Github Actions

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -63,7 +63,7 @@ jobs:
         submodules: true
 
     - name: Install dependencies
-      run: brew update && brew install boost gsl hdf5 cmake python
+      run: brew update && brew upgrade && brew install boost gsl hdf5 cmake python
 
     - name: Build and Install ecell4_base
       run: /usr/local/bin/python3 setup.py install


### PR DESCRIPTION
Fix the problem of failing [the CI with OSX](https://github.com/ecell/ecell4_base/commit/82ab95ffbbe31978048717e160a04098218eabe4/checks?check_suite_id=366159063) on Github Actions.