### PR TITLE
:recycle: replace boost::scoped_ptr by std::unique_ptr

### DIFF
--- a/ecell4/bd/BDSimulator.cpp
+++ b/ecell4/bd/BDSimulator.cpp
@@ -1,7 +1,5 @@
 #include "BDSimulator.hpp"
 
-#include <boost/scoped_array.hpp>
-
 #include <cstring>
 
 namespace ecell4

--- a/ecell4/bd/BDWorld.hpp
+++ b/ecell4/bd/BDWorld.hpp
@@ -1,9 +1,9 @@
 #ifndef ECELL4_BD_BD_WORLD_HPP
 #define ECELL4_BD_BD_WORLD_HPP
 
-#include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
+#include <memory>
 #include <sstream>
 
 #include <ecell4/core/exceptions.hpp>
@@ -336,11 +336,11 @@ public:
     void save(const std::string& filename) const
     {
 #ifdef WITH_HDF5
-        boost::scoped_ptr<H5::H5File>
+        std::unique_ptr<H5::H5File>
             fout(new H5::H5File(filename.c_str(), H5F_ACC_TRUNC));
         rng_->save(fout.get());
         pidgen_.save(fout.get());
-        boost::scoped_ptr<H5::Group>
+        std::unique_ptr<H5::Group>
             group(new H5::Group(fout->createGroup("ParticleSpace")));
         ps_->save_hdf5(group.get());
         extras::save_version_information(fout.get(), std::string("ecell4-bd-") + std::string(VERSION_INFO));
@@ -353,7 +353,7 @@ public:
     void load(const std::string& filename)
     {
 #ifdef WITH_HDF5
-        boost::scoped_ptr<H5::H5File>
+        std::unique_ptr<H5::H5File>
             fin(new H5::H5File(filename.c_str(), H5F_ACC_RDONLY));
 
         const std::string required = "ecell4-bd-0.0";
@@ -404,7 +404,7 @@ public:
 
 protected:
 
-    boost::scoped_ptr<ParticleSpace> ps_;
+    std::unique_ptr<ParticleSpace> ps_;
     boost::shared_ptr<RandomNumberGenerator> rng_;
     SerialIDGenerator<ParticleID> pidgen_;
 

--- a/ecell4/core/BDMLWriter.hpp
+++ b/ecell4/core/BDMLWriter.hpp
@@ -3,7 +3,6 @@
 
 #include <cstring>
 #include <boost/scoped_array.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <sstream>
 
@@ -151,11 +150,11 @@ void save_bd5(
     void* client_data;
     H5::Exception::getAutoPrint(func, &client_data);
 
-    boost::scoped_ptr<H5::H5File> fout;
+    std::unique_ptr<H5::H5File> fout;
     bool file_exists = false;
     if (trunc)
     {
-        boost::scoped_ptr<H5::H5File> tmp(new H5::H5File(filename.c_str(), H5F_ACC_TRUNC));
+        std::unique_ptr<H5::H5File> tmp(new H5::H5File(filename.c_str(), H5F_ACC_TRUNC));
         fout.swap(tmp);
     }
     else
@@ -163,7 +162,7 @@ void save_bd5(
         H5::Exception::dontPrint();
         try
         {
-            boost::scoped_ptr<H5::H5File> tmp(new H5::H5File(filename.c_str(), H5F_ACC_RDWR));
+            std::unique_ptr<H5::H5File> tmp(new H5::H5File(filename.c_str(), H5F_ACC_RDWR));
             fout.swap(tmp);
             H5::Exception::setAutoPrint(func, client_data);
             file_exists = true;
@@ -171,16 +170,16 @@ void save_bd5(
         catch (H5::FileIException &file_exists_err)
         {
             H5::Exception::setAutoPrint(func, client_data);
-            boost::scoped_ptr<H5::H5File> tmp(new H5::H5File(filename.c_str(), H5F_ACC_TRUNC));
+            std::unique_ptr<H5::H5File> tmp(new H5::H5File(filename.c_str(), H5F_ACC_TRUNC));
             fout.swap(tmp);
         }
     }
 
-    boost::scoped_ptr<H5::Group> data;
+    std::unique_ptr<H5::Group> data;
 
     if (!file_exists)
     {
-        boost::scoped_ptr<H5::Group>
+        std::unique_ptr<H5::Group>
             tmp(new H5::Group(fout->createGroup("data")));
         data.swap(tmp);
 
@@ -193,7 +192,7 @@ void save_bd5(
             const int RANK = 1;
             hsize_t dim[] = {1};
             H5::DataSpace dataspace(RANK, dim);
-            boost::scoped_ptr<H5::DataSet> objectDef(
+            std::unique_ptr<H5::DataSet> objectDef(
                 new H5::DataSet(data->createDataSet("objectDef", traits_type::get_bdml_objectDef_comp_type(), dataspace)));
             objectDef->write(objectDef_table.get(), objectDef->getDataType());
         }
@@ -212,14 +211,14 @@ void save_bd5(
             const int RANK = 1;
             hsize_t dim[] = {1};
             H5::DataSpace dataspace(RANK, dim);
-            boost::scoped_ptr<H5::DataSet> scaleUnit(
+            std::unique_ptr<H5::DataSet> scaleUnit(
                 new H5::DataSet(data->createDataSet("scaleUnit", traits_type::get_bdml_scaleUnit_comp_type(), dataspace)));
             scaleUnit->write(scaleUnit_table.get(), scaleUnit->getDataType());
         }
     }
     else
     {
-        boost::scoped_ptr<H5::Group>
+        std::unique_ptr<H5::Group>
             tmp(new H5::Group(fout->openGroup("data")));
         data.swap(tmp);
     }
@@ -237,9 +236,9 @@ void save_bd5(
     {
         H5::Exception::setAutoPrint(func, client_data);
 
-        boost::scoped_ptr<H5::Group>
+        std::unique_ptr<H5::Group>
             data_zero(new H5::Group(data->createGroup(group_name.c_str())));
-        boost::scoped_ptr<H5::Group>
+        std::unique_ptr<H5::Group>
             data_zero_object(new H5::Group(data_zero->createGroup("object")));
 
         typedef std::vector<std::pair<ParticleID, Particle> >
@@ -274,7 +273,7 @@ void save_bd5(
             const int RANK = 1;
             hsize_t dim[] = {NUM_MOL};
             H5::DataSpace dataspace(RANK, dim);
-            boost::scoped_ptr<H5::DataSet> data_zero_object_zero(
+            std::unique_ptr<H5::DataSet> data_zero_object_zero(
                 new H5::DataSet(data_zero_object->createDataSet(
                     "0", traits_type::get_bdml_sphere_comp_type(), dataspace)));
             data_zero_object_zero->write(data_table.get(), data_zero_object_zero->getDataType());
@@ -304,7 +303,7 @@ void save_bd5(
             const int RANK = 1;
             hsize_t dim[] = {NUM_MOL};
             H5::DataSpace dataspace(RANK, dim);
-            boost::scoped_ptr<H5::DataSet> data_zero_object_zero(
+            std::unique_ptr<H5::DataSet> data_zero_object_zero(
                 new H5::DataSet(data_zero_object->createDataSet(
                     "0", traits_type::get_bdml_point_comp_type(), dataspace)));
             data_zero_object_zero->write(data_table.get(), data_zero_object_zero->getDataType());

--- a/ecell4/core/CompartmentSpaceHDF5Writer.hpp
+++ b/ecell4/core/CompartmentSpaceHDF5Writer.hpp
@@ -2,7 +2,6 @@
 #define ECELL4_COMPARTMENT_SPACE_HDF5_WRITER_HPP
 
 #include <cstring>
-#include <boost/scoped_ptr.hpp>
 #include <boost/scoped_array.hpp>
 
 #include <hdf5.h>
@@ -172,11 +171,11 @@ void save_compartment_space(const typename Ttraits_::space_type& space, H5::Grou
     dim[0] = num_species;
     H5::DataSpace dataspace(RANK, dim);
 
-    boost::scoped_ptr<H5::DataSet> dataset_id_table(new H5::DataSet(
+    std::unique_ptr<H5::DataSet> dataset_id_table(new H5::DataSet(
         root->createDataSet(
             "species", traits_type::get_species_id_table_struct_memtype(),
             dataspace)));
-    boost::scoped_ptr<H5::DataSet> dataset_num_table(new H5::DataSet(
+    std::unique_ptr<H5::DataSet> dataset_num_table(new H5::DataSet(
         root->createDataSet(
             "num_molecules", traits_type::get_species_num_struct_memtype(),
             dataspace)));

--- a/ecell4/core/LatticeSpaceHDF5Writer.hpp
+++ b/ecell4/core/LatticeSpaceHDF5Writer.hpp
@@ -3,7 +3,6 @@
 
 #include <boost/lexical_cast.hpp>
 #include <boost/scoped_array.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <cstring>
 #include <iostream>
 #include <map>
@@ -58,7 +57,7 @@ struct LatticeSpaceHDF5Traits
                                 std::vector<VoxelView> voxels, H5::Group *group)
     {
         const Species species(mtb->species());
-        boost::scoped_ptr<H5::Group> mtgroup(
+        std::unique_ptr<H5::Group> mtgroup(
             new H5::Group(group->createGroup(species.serial().c_str())));
 
         h5_species_struct property;
@@ -102,7 +101,7 @@ struct LatticeSpaceHDF5Traits
         H5::CompType voxel_comp_type(get_voxel_comp());
         hsize_t dims[] = {(hsize_t)num_voxels};
         H5::DataSpace dspace(/* RANK= */ 1, dims);
-        boost::scoped_ptr<H5::DataSet> dset(new H5::DataSet(
+        std::unique_ptr<H5::DataSet> dset(new H5::DataSet(
             mtgroup->createDataSet("voxels", voxel_comp_type, dspace)));
         dset->write(h5_voxel_array.get(), dset->getDataType());
     }
@@ -146,7 +145,7 @@ void save_lattice_space(const Tspace_ &space, H5::Group *root,
 {
     typedef LatticeSpaceHDF5Traits traits_type;
 
-    boost::scoped_ptr<H5::Group> spgroup(
+    std::unique_ptr<H5::Group> spgroup(
         new H5::Group(root->createGroup("species")));
 
     const std::vector<Species> species(space.list_species());

--- a/ecell4/core/ParticleSpaceHDF5Writer.hpp
+++ b/ecell4/core/ParticleSpaceHDF5Writer.hpp
@@ -2,7 +2,6 @@
 #define ECELL4_PARTICLE_SPACE_HDF5_WRITER_HPP
 
 #include <cstring>
-#include <boost/scoped_ptr.hpp>
 #include <boost/scoped_array.hpp>
 
 #include <hdf5.h>
@@ -151,13 +150,13 @@ void save_particle_space(const Tspace_& space, H5::Group* root)
     const int RANK = 1;
     hsize_t dim1[] = {num_particles};
     H5::DataSpace dataspace1(RANK, dim1);
-    boost::scoped_ptr<H5::DataSet> dataset1(new H5::DataSet(
+    std::unique_ptr<H5::DataSet> dataset1(new H5::DataSet(
         root->createDataSet(
             "particles", traits_type::get_particle_comp_type(), dataspace1)));
 
     hsize_t dim2[] = {species.size()};
     H5::DataSpace dataspace2(RANK, dim2);
-    boost::scoped_ptr<H5::DataSet> dataset2(new H5::DataSet(
+    std::unique_ptr<H5::DataSet> dataset2(new H5::DataSet(
         root->createDataSet(
             "species", traits_type::get_species_comp_type(), dataspace2)));
 

--- a/ecell4/core/PolygonHDF5Writer.hpp
+++ b/ecell4/core/PolygonHDF5Writer.hpp
@@ -2,7 +2,6 @@
 #define ECELL4_POLYGON_HDF5_WRITER_HPP
 
 #include <cstring>
-#include <boost/scoped_ptr.hpp>
 #include <boost/scoped_array.hpp>
 
 #include <hdf5.h>
@@ -83,7 +82,7 @@ save_triangles_polygon(const T& p, H5::Group* root)
     const int     RANK   = 1;
     const hsize_t dim1[] = {num_triangles};
     H5::DataSpace dataspace(RANK, dim1);
-    boost::scoped_ptr<H5::DataSet> dataset(new H5::DataSet(
+    std::unique_ptr<H5::DataSet> dataset(new H5::DataSet(
         root->createDataSet(
             "triangles", traits_type::get_triangle_comp_type(), dataspace)));
     dataset->write(h5_triangle_table.get(), dataset->getDataType());

--- a/ecell4/core/RandomNumberGenerator.cpp
+++ b/ecell4/core/RandomNumberGenerator.cpp
@@ -1,4 +1,3 @@
-#include <boost/scoped_ptr.hpp>
 #include <gsl/gsl_rng.h>
 #include <sstream>
 
@@ -16,11 +15,11 @@ void GSLRandomNumberGenerator::save(H5::H5Location* root) const
 {
     using namespace H5;
 
-    boost::scoped_ptr<DataType> optype(new DataType(H5T_OPAQUE, 1));
+    std::unique_ptr<DataType> optype(new DataType(H5T_OPAQUE, 1));
     hsize_t bufsize(gsl_rng_size(rng_.get()));
     DataSpace dataspace(1, &bufsize);
     optype->setTag("GSLRandomNumberGenerator state type");
-    boost::scoped_ptr<DataSet> dataset(
+    std::unique_ptr<DataSet> dataset(
         new DataSet(root->createDataSet("rng", *optype, dataspace)));
     dataset->write((unsigned char*)(gsl_rng_state(rng_.get())), *optype);
 }
@@ -31,7 +30,7 @@ void GSLRandomNumberGenerator::load(const H5::H5Location& root)
 
     const DataSet dataset(DataSet(root.openDataSet("rng")));
     // size_t bufsize(gsl_rng_size(rng_.get()));
-    boost::scoped_ptr<DataType> optype(new DataType(H5T_OPAQUE, 1));
+    std::unique_ptr<DataType> optype(new DataType(H5T_OPAQUE, 1));
     optype->setTag("GSLRandomNumberGenerator state type");
     unsigned char* state = (unsigned char*)(gsl_rng_state(rng_.get()));
     dataset.read(state, *optype);
@@ -39,7 +38,7 @@ void GSLRandomNumberGenerator::load(const H5::H5Location& root)
 
 void GSLRandomNumberGenerator::save(const std::string& filename) const
 {
-    boost::scoped_ptr<H5::H5File>
+    std::unique_ptr<H5::H5File>
         fout(new H5::H5File(filename.c_str(), H5F_ACC_TRUNC));
     this->save(fout.get());
     extras::save_version_information(fout.get(), std::string("ecell4-gsl_number_generator-") + std::string(VERSION_INFO));
@@ -47,7 +46,7 @@ void GSLRandomNumberGenerator::save(const std::string& filename) const
 
 void GSLRandomNumberGenerator::load(const std::string& filename)
 {
-    boost::scoped_ptr<H5::H5File>
+    std::unique_ptr<H5::H5File>
         fin(new H5::H5File(filename.c_str(), H5F_ACC_RDONLY));
     this->load(*fin);
 }

--- a/ecell4/core/SerialIDGenerator.hpp
+++ b/ecell4/core/SerialIDGenerator.hpp
@@ -2,8 +2,8 @@
 #define ECELL4_SERIAL_ID_GENERATOR_HPP
 
 #include <functional>
+#include <memory>
 #include <boost/type_traits/is_integral.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include <ecell4/core/config.h>
 
@@ -328,11 +328,11 @@ public:
     {
         using namespace H5;
 
-        boost::scoped_ptr<DataType> optype(new DataType(H5T_OPAQUE, 1));
+        std::unique_ptr<DataType> optype(new DataType(H5T_OPAQUE, 1));
         hsize_t bufsize(sizeof(identifier_type));
         DataSpace dataspace(1, &bufsize);
         optype->setTag("SerialIDGenerator state type");
-        boost::scoped_ptr<DataSet> dataset(
+        std::unique_ptr<DataSet> dataset(
             new DataSet(root->createDataSet("idgen", *optype, dataspace)));
         dataset->write((unsigned char*)(&next_), *optype);
     }
@@ -342,7 +342,7 @@ public:
         using namespace H5;
 
         const DataSet dataset(DataSet(root.openDataSet("idgen")));
-        boost::scoped_ptr<DataType> optype(new DataType(H5T_OPAQUE, 1));
+        std::unique_ptr<DataType> optype(new DataType(H5T_OPAQUE, 1));
         optype->setTag("SerialIDGenerator state type");
         identifier_type state;
         dataset.read((unsigned char*)(&state), *optype);

--- a/ecell4/core/SubvolumeSpaceHDF5Writer.hpp
+++ b/ecell4/core/SubvolumeSpaceHDF5Writer.hpp
@@ -4,7 +4,6 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/multi_array.hpp>
 #include <boost/scoped_array.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <cstring>
 #include <iostream>
 #include <sstream>
@@ -143,22 +142,22 @@ void save_subvolume_space(const Tspace_ &space, H5::Group *root)
 
     hsize_t dim1[] = {species.size(), num_subvolumes};
     H5::DataSpace dataspace1(RANK1, dim1);
-    boost::scoped_ptr<H5::DataSet> dataset1(new H5::DataSet(root->createDataSet(
+    std::unique_ptr<H5::DataSet> dataset1(new H5::DataSet(root->createDataSet(
         "num_molecules", H5::PredType::STD_I64LE, dataspace1)));
 
     hsize_t dim2[] = {species.size()};
     H5::DataSpace dataspace2(RANK2, dim2);
-    boost::scoped_ptr<H5::DataSet> dataset2(new H5::DataSet(root->createDataSet(
+    std::unique_ptr<H5::DataSet> dataset2(new H5::DataSet(root->createDataSet(
         "species", traits_type::get_species_comp_type(), dataspace2)));
 
     hsize_t dim3[] = {structures.size(), num_subvolumes};
     H5::DataSpace dataspace3(RANK1, dim3);
-    boost::scoped_ptr<H5::DataSet> dataset3(new H5::DataSet(root->createDataSet(
+    std::unique_ptr<H5::DataSet> dataset3(new H5::DataSet(root->createDataSet(
         "stcoordinates", H5::PredType::IEEE_F64LE, dataspace3)));
 
     hsize_t dim4[] = {structures.size()};
     H5::DataSpace dataspace4(RANK2, dim4);
-    boost::scoped_ptr<H5::DataSet> dataset4(new H5::DataSet(root->createDataSet(
+    std::unique_ptr<H5::DataSet> dataset4(new H5::DataSet(root->createDataSet(
         "structures", traits_type::get_structures_comp_type(), dataspace4)));
 
     dataset1->write(h5_num_table.data(), dataset1->getDataType());

--- a/ecell4/core/extras.cpp
+++ b/ecell4/core/extras.cpp
@@ -57,7 +57,7 @@ void save_version_information(H5::H5Location* root, const std::string& version)
         throw IllegalArgument("Version info must be shorter than 32 characters.");
     }
     using namespace H5;
-    boost::scoped_ptr<DataSet> dataset(
+    std::unique_ptr<DataSet> dataset(
         new DataSet(root->createDataSet("version", H5::StrType(H5::PredType::C_S1, 32), H5::DataSpace(H5S_SCALAR))));
     dataset->write(version.c_str(), dataset->getDataType());
 }
@@ -76,7 +76,7 @@ std::string load_version_information(const std::string& filename)
 {
 #ifdef WITH_HDF5
     using namespace H5;
-    boost::scoped_ptr<H5::H5File>
+    std::unique_ptr<H5::H5File>
         fin(new H5::H5File(filename.c_str(), H5F_ACC_RDONLY));
     return load_version_information(*fin);
 #else

--- a/ecell4/core/extras.hpp
+++ b/ecell4/core/extras.hpp
@@ -2,7 +2,6 @@
 #define ECELL4_EXTRAS_HPP
 
 #include <boost/shared_ptr.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include <ecell4/core/config.h>
 

--- a/ecell4/core/tests/LatticeSpace_test.cpp
+++ b/ecell4/core/tests/LatticeSpace_test.cpp
@@ -595,7 +595,7 @@ BOOST_AUTO_TEST_CASE(LatticeSpace_test_save_and_load)
         space.update_voxel(sidgen(), Species("B", 2.5e-9, 1e-12), point));
 
     H5::H5File fout("data.h5", H5F_ACC_TRUNC);
-    boost::scoped_ptr<H5::Group> group(
+    std::unique_ptr<H5::Group> group(
         new H5::Group(fout.createGroup("VoxelSpaceBase")));
     space.save_hdf5(group.get());
     fout.close();

--- a/ecell4/core/tests/ParticleSpaceRTreeImpl_test.cpp
+++ b/ecell4/core/tests/ParticleSpaceRTreeImpl_test.cpp
@@ -31,7 +31,7 @@ BOOST_FIXTURE_TEST_SUITE(suite, Fixture)
 
 BOOST_AUTO_TEST_CASE(ParticleSpace_test_constructor)
 {
-    boost::scoped_ptr<ParticleSpace> space(new particle_space_type(edge_lengths));
+    std::unique_ptr<ParticleSpace> space(new particle_space_type(edge_lengths));
 
     BOOST_CHECK_EQUAL((*space).list_species().size(), 0);
     BOOST_CHECK_EQUAL((*space).num_particles(), 0);
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(ParticleSpace_test_constructor)
 
 BOOST_AUTO_TEST_CASE(ParticleSpace_test_update_remove)
 {
-    boost::scoped_ptr<ParticleSpace> space(new particle_space_type(edge_lengths));
+    std::unique_ptr<ParticleSpace> space(new particle_space_type(edge_lengths));
     SerialIDGenerator<ParticleID> pidgen;
 
     const ParticleID pid1 = pidgen();
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(ParticleSpace_test_update_remove)
 
 BOOST_AUTO_TEST_CASE(ParticleSpace_test_remove)
 {
-    boost::scoped_ptr<ParticleSpace> space(new particle_space_type(edge_lengths));
+    std::unique_ptr<ParticleSpace> space(new particle_space_type(edge_lengths));
     SerialIDGenerator<ParticleID> pidgen;
 
     const ParticleID pid1 = pidgen();
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(ParticleSpace_test_remove)
 
 BOOST_AUTO_TEST_CASE(ParticleSpace_test_exception)
 {
-    boost::scoped_ptr<ParticleSpace> space(new particle_space_type(edge_lengths));
+    std::unique_ptr<ParticleSpace> space(new particle_space_type(edge_lengths));
     SerialIDGenerator<ParticleID> pidgen;
     const ParticleID pid1 = pidgen();
 
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(ParticleSpace_test_exception)
 
 BOOST_AUTO_TEST_CASE(ParticleSpace_test_list_particles_within_radius)
 {
-    boost::scoped_ptr<ParticleSpace> space(new particle_space_type(edge_lengths));
+    std::unique_ptr<ParticleSpace> space(new particle_space_type(edge_lengths));
     SerialIDGenerator<ParticleID> pidgen;
 
     const ParticleID pid1 = pidgen();
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(ParticleSpace_test_list_particles_within_radius)
 
 BOOST_AUTO_TEST_CASE(ParticleSpace_test_list_particles_within_radius_boundary_x)
 {
-    boost::scoped_ptr<ParticleSpace> space(new particle_space_type(edge_lengths));
+    std::unique_ptr<ParticleSpace> space(new particle_space_type(edge_lengths));
     SerialIDGenerator<ParticleID> pidgen;
 
     const ParticleID pid1 = pidgen();
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(ParticleSpace_test_list_particles_within_radius_boundary_x)
 
 BOOST_AUTO_TEST_CASE(ParticleSpace_test_list_particles_within_radius_boundary_xyz)
 {
-    boost::scoped_ptr<ParticleSpace> space(new particle_space_type(edge_lengths));
+    std::unique_ptr<ParticleSpace> space(new particle_space_type(edge_lengths));
     SerialIDGenerator<ParticleID> pidgen;
 
     const ParticleID pid1 = pidgen();
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(ParticleSpace_test_list_particles_within_radius_boundary_xy
 
 BOOST_AUTO_TEST_CASE(ParticleSpaceRTreeImpl_test_constructor)
 {
-    boost::scoped_ptr<ParticleSpaceRTreeImpl> space(new ParticleSpaceRTreeImpl(edge_lengths));
+    std::unique_ptr<ParticleSpaceRTreeImpl> space(new ParticleSpaceRTreeImpl(edge_lengths));
 
     BOOST_CHECK_EQUAL(space->edge_lengths()[0], edge_lengths[0]);
     BOOST_CHECK_EQUAL(space->edge_lengths()[1], edge_lengths[1]);

--- a/ecell4/core/tests/ParticleSpace_test.cpp
+++ b/ecell4/core/tests/ParticleSpace_test.cpp
@@ -33,7 +33,7 @@ BOOST_FIXTURE_TEST_SUITE(suite, Fixture)
 
 BOOST_AUTO_TEST_CASE(ParticleSpace_test_constructor)
 {
-    boost::scoped_ptr<ParticleSpace> space(new particle_space_type(edge_lengths, matrix_sizes));
+    std::unique_ptr<ParticleSpace> space(new particle_space_type(edge_lengths, matrix_sizes));
 
     BOOST_CHECK_EQUAL((*space).list_species().size(), 0);
     BOOST_CHECK_EQUAL((*space).num_particles(), 0);
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(ParticleSpace_test_constructor)
 
 BOOST_AUTO_TEST_CASE(ParticleSpace_test_update_remove)
 {
-    boost::scoped_ptr<ParticleSpace> space(new particle_space_type(edge_lengths, matrix_sizes));
+    std::unique_ptr<ParticleSpace> space(new particle_space_type(edge_lengths, matrix_sizes));
     SerialIDGenerator<ParticleID> pidgen;
 
     const ParticleID pid1 = pidgen();
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(ParticleSpace_test_update_remove)
 
 BOOST_AUTO_TEST_CASE(ParticleSpace_test_remove)
 {
-    boost::scoped_ptr<ParticleSpace> space(new particle_space_type(edge_lengths, matrix_sizes));
+    std::unique_ptr<ParticleSpace> space(new particle_space_type(edge_lengths, matrix_sizes));
     SerialIDGenerator<ParticleID> pidgen;
 
     const ParticleID pid1 = pidgen();
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(ParticleSpace_test_remove)
 
 BOOST_AUTO_TEST_CASE(ParticleSpace_test_exception)
 {
-    boost::scoped_ptr<ParticleSpace> space(new particle_space_type(edge_lengths, matrix_sizes));
+    std::unique_ptr<ParticleSpace> space(new particle_space_type(edge_lengths, matrix_sizes));
     SerialIDGenerator<ParticleID> pidgen;
     const ParticleID pid1 = pidgen();
 
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(ParticleSpace_test_exception)
 
 BOOST_AUTO_TEST_CASE(ParticleSpace_test_list_particles_within_radius)
 {
-    boost::scoped_ptr<ParticleSpace> space(new particle_space_type(edge_lengths, matrix_sizes));
+    std::unique_ptr<ParticleSpace> space(new particle_space_type(edge_lengths, matrix_sizes));
     SerialIDGenerator<ParticleID> pidgen;
 
     const ParticleID pid1 = pidgen();
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(ParticleSpace_test_list_particles_within_radius)
 
 BOOST_AUTO_TEST_CASE(ParticleSpaceCellListImpl_test_constructor)
 {
-    boost::scoped_ptr<ParticleSpaceCellListImpl> space(new ParticleSpaceCellListImpl(edge_lengths, matrix_sizes));
+    std::unique_ptr<ParticleSpaceCellListImpl> space(new ParticleSpaceCellListImpl(edge_lengths, matrix_sizes));
 
     BOOST_CHECK_EQUAL((*space).matrix_sizes(), matrix_sizes);
 }

--- a/ecell4/egfrd/BDPropagator.hpp
+++ b/ecell4/egfrd/BDPropagator.hpp
@@ -10,7 +10,6 @@
 #include <boost/range/end.hpp>
 #include <boost/range/const_iterator.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <boost/scoped_ptr.hpp>
 #include "Defs.hpp"
 #include "generator.hpp"
 #include "exceptions.hpp"

--- a/ecell4/egfrd/EGFRDSimulator.hpp
+++ b/ecell4/egfrd/EGFRDSimulator.hpp
@@ -7,7 +7,6 @@
 #include <boost/foreach.hpp>
 #include <boost/optional.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/fusion/container/map.hpp>
 #include <boost/fusion/algorithm/iteration/for_each.hpp>
@@ -654,7 +653,7 @@ protected:
         position_type draw_iv(spherical_pair_type const& domain,
                               time_type dt, position_type const& old_iv) const
         {
-            boost::scoped_ptr<greens_functions::PairGreensFunction> const gf(
+            std::unique_ptr<greens_functions::PairGreensFunction> const gf(
                 choose_pair_greens_function(domain, dt));
             length_type const r(draw_r(
                 rng_, *gf, dt, domain.a_r(), domain.sigma()));
@@ -719,7 +718,7 @@ protected:
     //     position_type draw_iv(spherical_pair_type const& domain,
     //                           time_type dt, position_type const& old_iv) const
     //     {
-    //         boost::scoped_ptr<greens_functions::PairGreensFunction> const gf(
+    //         std::unique_ptr<greens_functions::PairGreensFunction> const gf(
     //             choose_pair_greens_function(domain, dt));
     //         length_type const r(draw_r(
     //             rng_, *gf, dt, domain.a_r(), domain.sigma()));
@@ -789,7 +788,7 @@ protected:
         position_type draw_iv(spherical_pair_type const& domain,
                               time_type dt, position_type const& old_iv)
         {
-            boost::scoped_ptr<greens_functions::PairGreensFunction> const gf(
+            std::unique_ptr<greens_functions::PairGreensFunction> const gf(
                 choose_pair_greens_function(domain, dt));
             length_type const r(domain.a_r());
             length_type const theta(draw_theta(rng_, *gf, dt, r));
@@ -858,7 +857,7 @@ protected:
         position_type draw_iv(spherical_pair_type const& domain,
                               time_type dt, position_type const& old_iv)
         {
-            boost::scoped_ptr<greens_functions::PairGreensFunction> const gf(
+            std::unique_ptr<greens_functions::PairGreensFunction> const gf(
                 choose_pair_greens_function(domain, dt));
             length_type const r(domain.sigma());
             length_type const theta(draw_theta(rng_, *gf, dt, r));
@@ -926,7 +925,7 @@ protected:
         position_type draw_iv(spherical_pair_type const& domain,
                               time_type dt, position_type const& old_iv)
         {
-            boost::scoped_ptr<greens_functions::PairGreensFunction> const gf(
+            std::unique_ptr<greens_functions::PairGreensFunction> const gf(
                 choose_pair_greens_function(domain, dt));
             length_type const r(draw_r(
                 rng_, *gf, dt, domain.a_r(), domain.sigma()));
@@ -1171,9 +1170,9 @@ public:
         if (edge_lengths != (*ssmat_).edge_lengths()
             || matrix_sizes != (*ssmat_).matrix_sizes())
         {
-            boost::scoped_ptr<spherical_shell_matrix_type>
+            std::unique_ptr<spherical_shell_matrix_type>
                 newssmat(new spherical_shell_matrix_type(edge_lengths, matrix_sizes));
-            boost::scoped_ptr<cylindrical_shell_matrix_type>
+            std::unique_ptr<cylindrical_shell_matrix_type>
                 newcsmat(new cylindrical_shell_matrix_type(edge_lengths, matrix_sizes));
             ssmat_.swap(newssmat);
             csmat_.swap(newcsmat);
@@ -1296,7 +1295,7 @@ public:
     // called by Multi
     void clear_volume(particle_shape_type const& p)
     {
-        boost::scoped_ptr<std::vector<domain_id_type> > domains(
+        std::unique_ptr<std::vector<domain_id_type> > domains(
             get_neighbor_domains(p));
         if (domains)
         {
@@ -1307,7 +1306,7 @@ public:
     void clear_volume(particle_shape_type const& p,
                       domain_id_type const& ignore)
     {
-        boost::scoped_ptr<std::vector<domain_id_type> > domains(
+        std::unique_ptr<std::vector<domain_id_type> > domains(
             get_neighbor_domains(p, ignore));
 
         if (domains)
@@ -3199,7 +3198,7 @@ protected:
                     return;
                 }
 
-                boost::scoped_ptr<std::vector<domain_id_type> > neighbors(
+                std::unique_ptr<std::vector<domain_id_type> > neighbors(
                     get_neighbor_domains(new_shell, single->id()));
 
                 std::vector<boost::shared_ptr<domain_type> > bursted;
@@ -3342,7 +3341,7 @@ protected:
                     closest = res.second;
                 }
 
-                boost::scoped_ptr<std::vector<domain_id_type> > _(intruders);
+                std::unique_ptr<std::vector<domain_id_type> > _(intruders);
 
                 LOG_DEBUG(("intruders: %s, closest: %s (dist=%.16g)",
                     intruders ?
@@ -4239,8 +4238,8 @@ protected:
     length_type const user_max_shell_size_;
 
     domain_map domains_;
-    boost::scoped_ptr<spherical_shell_matrix_type> ssmat_;
-    boost::scoped_ptr<cylindrical_shell_matrix_type> csmat_;
+    std::unique_ptr<spherical_shell_matrix_type> ssmat_;
+    std::unique_ptr<cylindrical_shell_matrix_type> csmat_;
     shell_matrix_map_type smatm_;
     shell_id_generator shidgen_;
     domain_id_generator didgen_;

--- a/ecell4/egfrd/Multi.hpp
+++ b/ecell4/egfrd/Multi.hpp
@@ -1,7 +1,6 @@
 #ifndef MULTI_HPP
 #define MULTI_HPP
 
-#include <boost/scoped_ptr.hpp>
 #include <boost/foreach.hpp>
 #include <boost/algorithm/string/join.hpp>
 
@@ -498,7 +497,7 @@ public:
 
     void step()
     {
-        boost::scoped_ptr<
+        std::unique_ptr<
             typename multi_particle_container_type::transaction_type>
                 tx(pc_.create_transaction());
         // typedef typename multi_particle_container_type::transaction_type::particle_id_pair_generator particle_id_pair_generator;

--- a/ecell4/egfrd/NetworkRulesAdapter.hpp
+++ b/ecell4/egfrd/NetworkRulesAdapter.hpp
@@ -4,7 +4,6 @@
 #include <map>
 #include <numeric>
 #include <vector>
-#include <boost/scoped_ptr.hpp>
 #include "twofold_container.hpp"
 #include "ReactionRuleInfo.hpp"
 #include "exceptions.hpp"

--- a/ecell4/egfrd/ParticleContainerBase.hpp
+++ b/ecell4/egfrd/ParticleContainerBase.hpp
@@ -162,7 +162,7 @@
 // 
 //     virtual void reset(const position_type& lengths, const matrix_sizes_type& sizes)
 //     {
-//         boost::scoped_ptr<particle_space_type>
+//         std::unique_ptr<particle_space_type>
 //             newps(new particle_space_type(lengths, sizes));
 //         ps_.swap(newps);
 // 
@@ -319,7 +319,7 @@
 // 
 // protected:
 // 
-//     boost::scoped_ptr<particle_space_type> ps_;
+//     std::unique_ptr<particle_space_type> ps_;
 // };
 // 
 // template<typename Tderived_, typename Ttraits_>

--- a/ecell4/egfrd/World.hpp
+++ b/ecell4/egfrd/World.hpp
@@ -417,11 +417,11 @@ public:
     virtual void save(const std::string& filename) const
     {
 #ifdef WITH_HDF5
-        boost::scoped_ptr<H5::H5File>
+        std::unique_ptr<H5::H5File>
             fout(new H5::H5File(filename.c_str(), H5F_ACC_TRUNC));
         rng_->save(fout.get());
         pidgen_.save(fout.get());
-        boost::scoped_ptr<H5::Group>
+        std::unique_ptr<H5::Group>
             group(new H5::Group(fout->createGroup("ParticleSpace")));
         //  ps_->save(group.get());
         ecell4::save_particle_space(*this, group.get());
@@ -454,7 +454,7 @@ public:
         //XXX: structures will be lost.
         //XXX: the order of particles in MatrixSpace will be lost.
         //XXX: initialize Simulator
-        boost::scoped_ptr<H5::H5File>
+        std::unique_ptr<H5::H5File>
             fin(new H5::H5File(filename.c_str(), H5F_ACC_RDONLY));
 
         const std::string required = "ecell4-egfrd-0.0";
@@ -504,7 +504,7 @@ public:
 
     virtual void reset(const position_type& lengths, const matrix_sizes_type& sizes)
     {
-        boost::scoped_ptr<particle_space_type>
+        std::unique_ptr<particle_space_type>
             newps(new particle_space_type(lengths, sizes));
         ps_.swap(newps);
 
@@ -1132,7 +1132,7 @@ protected:
 
 protected:
 
-    boost::scoped_ptr<particle_space_type> ps_;
+    std::unique_ptr<particle_space_type> ps_;
 
     Polygon<position_type> polygon_;
 

--- a/ecell4/egfrd/samples/mymapk.cpp
+++ b/ecell4/egfrd/samples/mymapk.cpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <numeric>
 #include <boost/shared_ptr.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <boost/foreach.hpp>
 #include <cstdlib>
 #include <gsl/gsl_roots.h>
@@ -230,7 +229,7 @@ int main(int argc, char **argv)
     // }}}
 
     // {
-    //     boost::scoped_ptr<world_type>
+    //     std::unique_ptr<world_type>
     //         world2(new world_type(ecell4::Real3(1, 2, 3), ecell4::Integer3(3, 6, 9)));
     //     std::cout << "edge_lengths:" << world2->edge_lengths()[0] << " " << world2->edge_lengths()[1] << " " << world2->edge_lengths()[2] << std::endl;
     //     std::cout << "matrix_sizes:" << world2->matrix_sizes()[0] << " " << world2->matrix_sizes()[1] << " " << world2->matrix_sizes()[2] << std::endl;

--- a/ecell4/egfrd/samples/polygon.cpp
+++ b/ecell4/egfrd/samples/polygon.cpp
@@ -7,7 +7,6 @@
 #include <string>
 #include <numeric>
 #include <boost/shared_ptr.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <boost/foreach.hpp>
 #include <cstdlib>
 #include <gsl/gsl_roots.h>

--- a/ecell4/gillespie/GillespieSimulator.cpp
+++ b/ecell4/gillespie/GillespieSimulator.cpp
@@ -9,8 +9,6 @@
 #include <cstring>
 #include <cmath>
 
-#include <boost/scoped_array.hpp>
-
 namespace ecell4
 {
 

--- a/ecell4/gillespie/GillespieWorld.hpp
+++ b/ecell4/gillespie/GillespieWorld.hpp
@@ -4,7 +4,6 @@
 #include <stdexcept>
 #include <sstream>
 #include <map>
-#include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
 #include <string>
@@ -97,10 +96,10 @@ public:
     void save(const std::string& filename) const
     {
 #ifdef WITH_HDF5
-        boost::scoped_ptr<H5::H5File>
+        std::unique_ptr<H5::H5File>
             fout(new H5::H5File(filename.c_str(), H5F_ACC_TRUNC));
         rng_->save(fout.get());
-        boost::scoped_ptr<H5::Group>
+        std::unique_ptr<H5::Group>
             group(new H5::Group(fout->createGroup("CompartmentSpace")));
         cs_->save_hdf5(group.get());
         extras::save_version_information(fout.get(), std::string("ecell4-gillespie-") + std::string(VERSION_INFO));
@@ -113,7 +112,7 @@ public:
     void load(const std::string& filename)
     {
 #ifdef WITH_HDF5
-        boost::scoped_ptr<H5::H5File>
+        std::unique_ptr<H5::H5File>
             fin(new H5::H5File(filename.c_str(), H5F_ACC_RDONLY));
 
         const std::string required = "ecell4-gillespie-0.0";
@@ -186,7 +185,7 @@ public:
 
 private:
 
-    boost::scoped_ptr<CompartmentSpace> cs_;
+    std::unique_ptr<CompartmentSpace> cs_;
     boost::shared_ptr<RandomNumberGenerator> rng_;
 
     boost::weak_ptr<Model> model_;

--- a/ecell4/meso/MesoscopicSimulator.cpp
+++ b/ecell4/meso/MesoscopicSimulator.cpp
@@ -7,8 +7,6 @@
 #include <cstdio>
 #include <cstring>
 
-#include <boost/scoped_array.hpp>
-
 #include "MesoscopicSimulator.hpp"
 
 

--- a/ecell4/meso/MesoscopicWorld.hpp
+++ b/ecell4/meso/MesoscopicWorld.hpp
@@ -3,7 +3,6 @@
 
 #include <numeric>
 #include <sstream>
-#include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
 
@@ -96,10 +95,10 @@ public:
     void save(const std::string& filename) const
     {
 #ifdef WITH_HDF5
-        boost::scoped_ptr<H5::H5File>
+        std::unique_ptr<H5::H5File>
             fout(new H5::H5File(filename.c_str(), H5F_ACC_TRUNC));
         rng_->save(fout.get());
-        boost::scoped_ptr<H5::Group>
+        std::unique_ptr<H5::Group>
             group(new H5::Group(fout->createGroup("SubvolumeSpace")));
         cs_->save_hdf5(group.get());
         extras::save_version_information(fout.get(), std::string("ecell4-meso-") + std::string(VERSION_INFO));
@@ -112,7 +111,7 @@ public:
     void load(const std::string& filename)
     {
 #ifdef WITH_HDF5
-        boost::scoped_ptr<H5::H5File>
+        std::unique_ptr<H5::H5File>
             fin(new H5::H5File(filename.c_str(), H5F_ACC_RDONLY));
 
         const std::string required = "ecell4-meso-0.0";
@@ -412,7 +411,7 @@ public:
 
 private:
 
-    boost::scoped_ptr<SubvolumeSpace> cs_;
+    std::unique_ptr<SubvolumeSpace> cs_;
     boost::shared_ptr<RandomNumberGenerator> rng_;
 
     boost::weak_ptr<Model> model_;

--- a/ecell4/ode/ODESimulator.hpp
+++ b/ecell4/ode/ODESimulator.hpp
@@ -6,8 +6,6 @@
 #include <numeric>
 #include <map>
 #include <boost/shared_ptr.hpp>
-#include <boost/scoped_ptr.hpp>
-#include <boost/scoped_array.hpp>
 
 #include <boost/numeric/ublas/vector.hpp>
 #include <boost/numeric/ublas/matrix.hpp>
@@ -93,7 +91,7 @@ public:
                 // Calculation! XXX
                 if (i->ratelaw.expired())
                 {
-                    boost::scoped_ptr<ReactionRuleDescriptor> temporary_ratelaw_obj(new ReactionRuleDescriptorMassAction(i->k, i->reactant_coefficients, i->product_coefficients));
+                    std::unique_ptr<ReactionRuleDescriptor> temporary_ratelaw_obj(new ReactionRuleDescriptorMassAction(i->k, i->reactant_coefficients, i->product_coefficients));
                     flux = temporary_ratelaw_obj->propensity(reactants_states, products_states, volume_, t);
                 }
                 else
@@ -188,7 +186,7 @@ public:
 
                 if (i->ratelaw.expired())
                 {
-                    boost::scoped_ptr<ReactionRuleDescriptor> temporary_ratelaw_obj(new ReactionRuleDescriptorMassAction(i->k, i->reactant_coefficients, i->product_coefficients));
+                    std::unique_ptr<ReactionRuleDescriptor> temporary_ratelaw_obj(new ReactionRuleDescriptorMassAction(i->k, i->reactant_coefficients, i->product_coefficients));
                     Real flux_0 = temporary_ratelaw_obj->propensity(reactants_states, products_states, volume_, t);
                     // Differentiate by time
                     {
@@ -400,7 +398,7 @@ public:
 
                 if (i->ratelaw.expired())
                 {
-                    boost::scoped_ptr<ReactionRuleDescriptor> temporary_ratelaw_obj(new ReactionRuleDescriptorMassAction(i->k, i->reactant_coefficients, i->product_coefficients));
+                    std::unique_ptr<ReactionRuleDescriptor> temporary_ratelaw_obj(new ReactionRuleDescriptorMassAction(i->k, i->reactant_coefficients, i->product_coefficients));
                     Real flux_0 = temporary_ratelaw_obj->propensity(reactants_states, products_states, volume_, t);
                     // Differentiate by each Reactants
                     for(std::size_t j(0); j < reactants_states.size(); j++)

--- a/ecell4/ode/ODEWorld.cpp
+++ b/ecell4/ode/ODEWorld.cpp
@@ -26,9 +26,9 @@ void ODEWorld::bind_to(boost::shared_ptr<Model> model)
 void ODEWorld::save(const std::string& filename) const
 {
 #ifdef WITH_HDF5
-    boost::scoped_ptr<H5::H5File>
+    std::unique_ptr<H5::H5File>
         fout(new H5::H5File(filename.c_str(), H5F_ACC_TRUNC));
-    boost::scoped_ptr<H5::Group>
+    std::unique_ptr<H5::Group>
         group(new H5::Group(fout->createGroup("CompartmentSpace")));
     save_compartment_space<ODEWorldHDF5Traits<ODEWorld> >(*this, group.get());
 
@@ -45,7 +45,7 @@ void ODEWorld::save(const std::string& filename) const
 void ODEWorld::load(const std::string& filename)
 {
 #ifdef WITH_HDF5
-    boost::scoped_ptr<H5::H5File>
+    std::unique_ptr<H5::H5File>
         fin(new H5::H5File(filename.c_str(), H5F_ACC_RDONLY));
 
     const std::string required = "ecell4-ode-0.0";

--- a/ecell4/sgfrd/SGFRDWorld.hpp
+++ b/ecell4/sgfrd/SGFRDWorld.hpp
@@ -13,7 +13,6 @@
 #include <ecell4/core/Model.hpp>
 #include <ecell4/core/collision.hpp>
 #include <boost/container/flat_map.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/smart_ptr/make_shared.hpp>
 #include <boost/weak_ptr.hpp>
@@ -162,16 +161,16 @@ class SGFRDWorld
     void save(const std::string& filename) const override
     {
 #ifdef WITH_HDF5
-        boost::scoped_ptr<H5::H5File>
+        std::unique_ptr<H5::H5File>
             fout(new H5::H5File(filename.c_str(), H5F_ACC_TRUNC));
         rng_->save(fout.get());
         pidgen_.save(fout.get());
 
-        boost::scoped_ptr<H5::Group>
+        std::unique_ptr<H5::Group>
             group1(new H5::Group(fout->createGroup("ParticleSpace")));
         ps_->save_hdf5(group1.get());
 
-        boost::scoped_ptr<H5::Group>
+        std::unique_ptr<H5::Group>
             group2(new H5::Group(fout->createGroup("Polygon")));
         this->polygon_->save_hdf5(group2.get());
 
@@ -187,7 +186,7 @@ class SGFRDWorld
     void load(const std::string& filename) override
     {
 #ifdef WITH_HDF5
-        boost::scoped_ptr<H5::H5File>
+        std::unique_ptr<H5::H5File>
             fin(new H5::H5File(filename.c_str(), H5F_ACC_RDONLY));
 
         const std::string required = "ecell4-sgfrd-0.0";
@@ -837,7 +836,7 @@ class SGFRDWorld
 
   private:
 
-    boost::scoped_ptr<particle_space_type>   ps_;
+    std::unique_ptr<particle_space_type>   ps_;
     boost::shared_ptr<RandomNumberGenerator> rng_;
     boost::weak_ptr<Model>                   model_;
     boost::shared_ptr<polygon_type>          polygon_;

--- a/ecell4/spatiocyte/SpatiocyteWorld.hpp
+++ b/ecell4/spatiocyte/SpatiocyteWorld.hpp
@@ -123,11 +123,11 @@ public:
     void save(const std::string &filename) const
     {
 #ifdef WITH_HDF5
-        boost::scoped_ptr<H5::H5File> fout(
+        std::unique_ptr<H5::H5File> fout(
             new H5::H5File(filename.c_str(), H5F_ACC_TRUNC));
         rng_->save(fout.get());
         sidgen_.save(fout.get());
-        boost::scoped_ptr<H5::Group> group(
+        std::unique_ptr<H5::Group> group(
             new H5::Group(fout->createGroup("LatticeSpace")));
         get_root()->save_hdf5(group.get()); // TODO
         extras::save_version_information(fout.get(),
@@ -142,7 +142,7 @@ public:
     void load(const std::string &filename)
     {
 #ifdef WITH_HDF5
-        boost::scoped_ptr<H5::H5File> fin(
+        std::unique_ptr<H5::H5File> fin(
             new H5::H5File(filename.c_str(), H5F_ACC_RDONLY));
 
         const std::string required = "ecell4-spatiocyte-0.0";


### PR DESCRIPTION
Since `std::move` is introduced after C++11, `boost::scoped_ptr` is not  movable.

By replacing it by `std::unique_ptr`, some of the ecell4 classes, such as `BDWorld`, will also be movable.
Additionally, by applying this change, `World` classes that contains `ParticleSpace*` will be able to be constructed from a `unique_ptr` to a `ParticleSpace` to change the `ParticleSpace` implementation at runtime.