### PR TITLE
:fire: remove global constants

### DIFF
--- a/ecell4/bd/BDSimulator.hpp
+++ b/ecell4/bd/BDSimulator.hpp
@@ -54,6 +54,7 @@ public:
 
     Real determine_dt() const
     {
+        constexpr Real inf = std::numeric_limits<Real>::infinity();
         Real rmin(inf), Dmax(0.0);
 
         for (std::vector<Species>::const_iterator i(model_->species_attributes().begin());

--- a/ecell4/core/AABBSurface.cpp
+++ b/ecell4/core/AABBSurface.cpp
@@ -118,7 +118,7 @@ std::pair<bool, Real> AABBSurface::intersect_ray(const Real3& p, const Real3& d)
         Real tmin = inf;
         for(std::size_t i=0; i<3; ++i)
         {
-            if(std::abs(d[i]) < epsilon) continue;
+            if(std::abs(d[i]) < std::numeric_limits<Real>::epsilon()) continue;
             const Real tmp = (d[i] > 0) ? (this->upper_[i] - p[i]) / d[i] :
                                           (this->lower_[i] - p[i]) / d[i] ;
             tmin = std::min(tmin, tmp);

--- a/ecell4/core/AABBSurface.cpp
+++ b/ecell4/core/AABBSurface.cpp
@@ -115,7 +115,7 @@ std::pair<bool, Real> AABBSurface::intersect_ray(const Real3& p, const Real3& d)
 {
     if(this->_is_inside(p))
     {
-        Real tmin = inf;
+        Real tmin = std::numeric_limits<Real>::infinity();
         for(std::size_t i=0; i<3; ++i)
         {
             if(std::abs(d[i]) < std::numeric_limits<Real>::epsilon()) continue;

--- a/ecell4/core/EventScheduler.hpp
+++ b/ecell4/core/EventScheduler.hpp
@@ -151,7 +151,7 @@ public:
         }
         else
         {
-            return inf;
+            return std::numeric_limits<Real>::infinity();
         }
     }
 

--- a/ecell4/core/Mesh.cpp
+++ b/ecell4/core/Mesh.cpp
@@ -74,7 +74,7 @@ Real MeshSurface::is_inside(const Real3& pos) const
     selectEnclosedPoints->SetInput(pointsPolydata);
     selectEnclosedPoints->SetSurface(reader_->GetOutput());
     selectEnclosedPoints->Update();
-    return (selectEnclosedPoints->IsInside(0) ? 0.0 : inf);
+    return (selectEnclosedPoints->IsInside(0) ? 0.0 : std::numeric_limits<Real>::infinity());
 
     // double lineP0[3];
     // lineP0[0] = pos[0] / ratio_ - shift_[0];

--- a/ecell4/core/PlanarSurface.cpp
+++ b/ecell4/core/PlanarSurface.cpp
@@ -46,6 +46,7 @@ bool PlanarSurface::test_AABB(const Real3& lower, const Real3& upper) const
 void PlanarSurface::bounding_box(
     const Real3& edge_lengths, Real3& lower, Real3& upper) const
 {
+    constexpr double epsilon = std::numeric_limits<Real>::epsilon();
     if (n_[0] > epsilon)
     {
         lower[0] = std::max(

--- a/ecell4/core/collision.cpp
+++ b/ecell4/core/collision.cpp
@@ -275,7 +275,7 @@ bool intersect_ray_AABB(
 {
     constexpr double epsilon = std::numeric_limits<Real>::epsilon();
     tmin = 0.0;
-    Real tmax(inf);
+    Real tmax(std::numeric_limits<Real>::infinity());
     const unsigned int ndim(3);
     for (unsigned int i(0); i < ndim; ++i)
     {
@@ -351,7 +351,7 @@ bool intersect_moving_sphere_AABB(
 
     if (m == 7)
     {
-        Real tmin(inf);
+        Real tmin(std::numeric_limits<Real>::infinity());
         if (intersect_segment_capsule(
             p0, p1, b.corner(v), b.corner(v^1), radius, t))
         {
@@ -368,7 +368,7 @@ bool intersect_moving_sphere_AABB(
             tmin = std::min(t, tmin);
         }
 
-        if (tmin == inf)
+        if (tmin == std::numeric_limits<Real>::infinity())
         {
             return false;
         }

--- a/ecell4/core/collision.cpp
+++ b/ecell4/core/collision.cpp
@@ -102,6 +102,7 @@ Real closest_point_segment_segment(
     const Real3& p2, const Real3& q2,
     Real& s, Real& t, Real3& c1, Real3& c2)
 {
+    constexpr double epsilon = std::numeric_limits<Real>::epsilon();
     const Real3 d1(q1 - p1);
     const Real3 d2(q2 - p2);
     const Real3 r(p1 - p2);
@@ -184,6 +185,7 @@ bool test_AABB_AABB(
 bool test_segment_AABB(
     const Real3& p0, const Real3& p1, const Real3& lower, const Real3& upper)
 {
+    constexpr double epsilon = std::numeric_limits<Real>::epsilon();
     const Real3 c((upper + lower) * 0.5);
     const Real3 e(upper - c);
     Real3 m(multiply(p1 - p0, 0.5));
@@ -271,6 +273,7 @@ bool intersect_ray_AABB(
     const Real3& p, const Real3& d, const Real3& lower, const Real3& upper,
     Real& tmin, Real3& q)
 {
+    constexpr double epsilon = std::numeric_limits<Real>::epsilon();
     tmin = 0.0;
     Real tmax(inf);
     const unsigned int ndim(3);

--- a/ecell4/core/observers.cpp
+++ b/ecell4/core/observers.cpp
@@ -6,7 +6,7 @@ namespace ecell4
 
 const Real Observer::next_time() const
 {
-    return inf;
+    return std::numeric_limits<Real>::infinity();
 }
 
 void Observer::initialize(const boost::shared_ptr<WorldInterface>& world, const boost::shared_ptr<Model>& model)
@@ -253,7 +253,7 @@ const Real TimingObserver::next_time() const
 {
     if (count_ >= static_cast<Integer>(t_.size()))
     {
-        return inf;
+        return std::numeric_limits<Real>::infinity();
     }
     return t_[count_];
 }

--- a/ecell4/core/observers.hpp
+++ b/ecell4/core/observers.hpp
@@ -637,7 +637,7 @@ struct TimingEvent
         {
             return times[count];
         }
-        return inf;
+        return std::numeric_limits<Real>::infinity();
     }
 
     void reset()
@@ -669,7 +669,7 @@ public:
 
 struct FixedIntervalEvent
 {
-    FixedIntervalEvent(const Real& dt = inf)
+    FixedIntervalEvent(const Real& dt = std::numeric_limits<Real>::infinity())
         : t0(0.0), dt(dt), num_steps(0), count(0)
     {
         ;
@@ -746,7 +746,7 @@ public:
         const std::vector<ParticleID>& pids,
         const bool resolve_boundary = default_resolve_boundary(),
         const Real subdt = default_subdt())
-        : base_type(false), event_(), subevent_(subdt > 0 ? subdt : inf),
+        : base_type(false), event_(), subevent_(subdt > 0 ? subdt : std::numeric_limits<Real>::infinity()),
         pids_(pids), resolve_boundary_(resolve_boundary), prev_positions_(pids.size()),
         trajectories_(pids.size()), strides_(pids.size()), t_()
     {
@@ -756,7 +756,7 @@ public:
     TrajectoryObserver(
         const bool resolve_boundary = default_resolve_boundary(),
         const Real subdt = default_subdt())
-        : base_type(false), event_(), subevent_(subdt > 0 ? subdt : inf),
+        : base_type(false), event_(), subevent_(subdt > 0 ? subdt : std::numeric_limits<Real>::infinity()),
         pids_(), resolve_boundary_(resolve_boundary), prev_positions_(),
         trajectories_(), strides_(), t_()
     {
@@ -1040,7 +1040,7 @@ public:
     }
 
     TimeoutObserver()
-        : base_type(true), interval_(inf), duration_(0.0), acc_(0.0)
+        : base_type(true), interval_(std::numeric_limits<Real>::infinity()), duration_(0.0), acc_(0.0)
     {
         ;
     }
@@ -1097,7 +1097,7 @@ public:
         const Real threshold = default_threshold())
         : base_type(false), event_(dt), subevent_(subdt > 0 ? subdt : dt),
         species_(species), resolve_boundary_(resolve_boundary),
-        threshold_(threshold > 0 ? threshold : inf),
+        threshold_(threshold > 0 ? threshold : std::numeric_limits<Real>::infinity()),
         prev_positions_(), strides_(), pids_(), trajectories_(), t_()
     {
         ;

--- a/ecell4/core/shape_operators.hpp
+++ b/ecell4/core/shape_operators.hpp
@@ -192,7 +192,7 @@ public:
         }
         else
         {
-            return inf;
+            return std::numeric_limits<Real>::infinity();
         }
     }
 

--- a/ecell4/core/types.hpp
+++ b/ecell4/core/types.hpp
@@ -15,7 +15,7 @@ typedef double Real;
 
 const double inf = HUGE_VAL; // infinity (double)
 // const Real N_A = 6.022140857e+23;
-const double epsilon = DBL_EPSILON; // std::numeric_limits<Real>::epsilon();
+// const double epsilon = DBL_EPSILON; // std::numeric_limits<Real>::epsilon();
 
 } // ecell4
 

--- a/ecell4/core/types.hpp
+++ b/ecell4/core/types.hpp
@@ -13,10 +13,5 @@ namespace ecell4
 typedef int64_t Integer;
 typedef double Real;
 
-// const double inf = HUGE_VAL; // infinity (double)
-// const Real N_A = 6.022140857e+23;
-// const double epsilon = DBL_EPSILON; // std::numeric_limits<Real>::epsilon();
-
 } // ecell4
-
 #endif /* ECELL4_TYPES_HPP */

--- a/ecell4/core/types.hpp
+++ b/ecell4/core/types.hpp
@@ -13,7 +13,7 @@ namespace ecell4
 typedef int64_t Integer;
 typedef double Real;
 
-const double inf = HUGE_VAL; // infinity (double)
+// const double inf = HUGE_VAL; // infinity (double)
 // const Real N_A = 6.022140857e+23;
 // const double epsilon = DBL_EPSILON; // std::numeric_limits<Real>::epsilon();
 

--- a/ecell4/core/types.hpp
+++ b/ecell4/core/types.hpp
@@ -14,7 +14,7 @@ typedef int64_t Integer;
 typedef double Real;
 
 const double inf = HUGE_VAL; // infinity (double)
-const Real N_A = 6.022140857e+23;
+// const Real N_A = 6.022140857e+23;
 const double epsilon = DBL_EPSILON; // std::numeric_limits<Real>::epsilon();
 
 } // ecell4

--- a/ecell4/gillespie/GillespieSimulator.cpp
+++ b/ecell4/gillespie/GillespieSimulator.cpp
@@ -52,7 +52,7 @@ bool GillespieSimulator::__draw_next_reaction(void)
     if (atot == 0.0)
     {
         // no reaction occurs
-        this->dt_ = inf;
+        this->dt_ = std::numeric_limits<Real>::infinity();
         return true;
     }
 
@@ -108,7 +108,7 @@ void GillespieSimulator::draw_next_reaction(void)
 {
     if (events_.size() == 0)
     {
-        this->dt_ = inf;
+        this->dt_ = std::numeric_limits<Real>::infinity();
         return;
     }
 
@@ -124,7 +124,7 @@ void GillespieSimulator::step(void)
 {
     last_reactions_.clear();
 
-    if (this->dt_ == inf)
+    if (this->dt_ == std::numeric_limits<Real>::infinity())
     {
         // No reaction occurs.
         return;

--- a/ecell4/meso/MesoscopicSimulator.cpp
+++ b/ecell4/meso/MesoscopicSimulator.cpp
@@ -72,6 +72,7 @@ void MesoscopicSimulator::decrement_molecules(const Species& sp, const coordinat
 std::pair<Real, MesoscopicSimulator::ReactionRuleProxyBase*>
 MesoscopicSimulator::draw_next_reaction(const coordinate_type& c)
 {
+    constexpr Real inf = std::numeric_limits<Real>::infinity();
     std::vector<double> a(proxies_.size());
     for (unsigned int idx(0); idx < proxies_.size(); ++idx)
     {
@@ -84,12 +85,12 @@ MesoscopicSimulator::draw_next_reaction(const coordinate_type& c)
         return std::make_pair(inf, (ReactionRuleProxyBase*)NULL);
     }
 
-    if (atot == std::numeric_limits<Real>::infinity())
+    if (atot == inf)
     {
         std::vector<unsigned int> selected;
         for (unsigned int i(0); i < a.size(); ++i)
         {
-            if (a[i] == std::numeric_limits<Real>::infinity())
+            if (a[i] == inf)
             {
                 selected.push_back(i);
             }
@@ -133,7 +134,7 @@ void MesoscopicSimulator::interrupt_all(const Real& t)
 
 void MesoscopicSimulator::step(void)
 {
-    if (this->dt() == inf)
+    if (this->dt() == std::numeric_limits<Real>::infinity())
     {
         // Any reactions cannot occur.
         return;

--- a/ecell4/meso/tests/MesoscopicSimulator_test.cpp
+++ b/ecell4/meso/tests/MesoscopicSimulator_test.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(MesoscopicSimulator_test_step)
     sim.step();
 
     BOOST_CHECK(0 < sim.t());
-    BOOST_CHECK(sim.t() < inf);
+    BOOST_CHECK(sim.t() < std::numeric_limits<Real>::infinity());
     BOOST_CHECK(world->num_molecules(sp1, 0) == 9);
     BOOST_CHECK(world->num_molecules(sp2, 0) == 1);
 }

--- a/ecell4/ode/ODEFactory.hpp
+++ b/ecell4/ode/ODEFactory.hpp
@@ -46,7 +46,7 @@ public:
 
     static inline const Real default_dt()
     {
-        return inf;
+        return std::numeric_limits<Real>::infinity();
     }
 
     static inline const Real default_abs_tol()

--- a/ecell4/ode/ODESimulator.hpp
+++ b/ecell4/ode/ODESimulator.hpp
@@ -495,8 +495,8 @@ public:
         const boost::shared_ptr<ODEWorld>& world,
         const boost::shared_ptr<Model>& model,
         const ODESolverType solver_type = ROSENBROCK4_CONTROLLER)
-        : base_type(world, model), dt_(inf), abs_tol_(1e-6), rel_tol_(1e-6), max_dt_(0.0),
-          solver_type_(solver_type)
+        : base_type(world, model), dt_(std::numeric_limits<Real>::infinity()),
+          abs_tol_(1e-6), rel_tol_(1e-6), max_dt_(0.0), solver_type_(solver_type)
     {
         initialize();
     }
@@ -504,8 +504,8 @@ public:
     ODESimulator(
         const boost::shared_ptr<ODEWorld>& world,
         const ODESolverType solver_type = ROSENBROCK4_CONTROLLER)
-        : base_type(world), dt_(inf), abs_tol_(1e-6), rel_tol_(1e-6), max_dt_(0.0),
-          solver_type_(solver_type)
+        : base_type(world), dt_(std::numeric_limits<Real>::infinity()),
+          abs_tol_(1e-6), rel_tol_(1e-6), max_dt_(0.0), solver_type_(solver_type)
     {
         initialize();
     }

--- a/ecell4/python_api/core.cpp
+++ b/ecell4/python_api/core.cpp
@@ -1246,7 +1246,7 @@ void setup_module(py::module& m)
     m.def("get_dimension_from_model", &extras::get_dimension_from_model);
     m.def("get_stoichiometry", &extras::get_stoichiometry);
     m.def("cbrt", &ecell4::cbrt);
-    m.attr("N_A") = N_A;
+    m.attr("N_A") = 6.022140857e+23;
     m.attr("epsilon") = epsilon;
     m.def("_save_bd5", &save_bd5);
 }

--- a/ecell4/python_api/core.cpp
+++ b/ecell4/python_api/core.cpp
@@ -1247,7 +1247,7 @@ void setup_module(py::module& m)
     m.def("get_stoichiometry", &extras::get_stoichiometry);
     m.def("cbrt", &ecell4::cbrt);
     m.attr("N_A") = 6.022140857e+23;
-    m.attr("epsilon") = epsilon;
+    m.attr("epsilon") = std::numeric_limits<Real>::epsilon();
     m.def("_save_bd5", &save_bd5);
 }
 

--- a/ecell4/spatiocyte/ReactionEvent.cpp
+++ b/ecell4/spatiocyte/ReactionEvent.cpp
@@ -63,7 +63,7 @@ Real ZerothOrderReactionEvent::draw_dt()
 {
     const Real k(rule_.k());
     const Real p = k * world_->volume();
-    Real dt(inf);
+    Real dt(std::numeric_limits<Real>::infinity());
     if (p != 0.)
     {
         const Real rnd(world_->rng()->uniform(0., 1.));
@@ -121,7 +121,7 @@ Real FirstOrderReactionEvent::draw_dt()
     if (num_r > 0)
     {
         const Real p = k * num_r;
-        Real dt(inf);
+        Real dt(std::numeric_limits<Real>::infinity());
         if (p != 0.)
         {
             const Real rnd(world_->rng()->uniform(0., 1.));
@@ -131,7 +131,7 @@ Real FirstOrderReactionEvent::draw_dt()
     }
     else
     {
-        return inf;
+        return std::numeric_limits<Real>::infinity();
     }
 }
 

--- a/ecell4/spatiocyte/SpatiocyteEvent.hpp
+++ b/ecell4/spatiocyte/SpatiocyteEvent.hpp
@@ -68,7 +68,7 @@ struct StepEvent : SpatiocyteEvent
         const Real R(world_->voxel_radius());
 
         if (D <= 0)
-            dt_ = inf;
+            dt_ = std::numeric_limits<Real>::infinity();
         else
             dt_ = calc_dt<Dimension>(R, D) * alpha_;
 


### PR DESCRIPTION
This removes the following global constants.
- `ecell4::inf`
  - replaced by `std::numeric_limits<Real>::infinity()`
- `ecell4::epsilon`
  - replaced by `std::numeric_limits<Real>::epsilon()`
- `ecell4::N_A`
  - it seems that it is not used

Currently, `N_A` is not used (except for the python module). But if it would be used somewhere later, I will restore the definition.