### PR TITLE
:fire: remove needless undef

### DIFF
--- a/ecell4/core/Polygon.hpp
+++ b/ecell4/core/Polygon.hpp
@@ -811,7 +811,6 @@ roll(const Polygon& poly,
 
 } // polygon
 } // ecell4
-#undef ECELL4_STRONG_TYPEDEF
 
 namespace std {
 


### PR DESCRIPTION
the macro is already removed. I just forgot to remove this undef.