### PR TITLE
:rotating_light: Suppress warnings

### DIFF
--- a/ecell4/core/Context.hpp
+++ b/ecell4/core/Context.hpp
@@ -175,7 +175,7 @@ public:
         results.push_back(ctx.get().iterators);
         std::sort(results.back().begin(), results.back().end());
 
-        while (ctx = next())
+        while((ctx = next()))
         {
             results.push_back(ctx.get().iterators);
             std::sort(results.back().begin(), results.back().end());

--- a/ecell4/core/ParticleSpaceRTreeImpl.hpp
+++ b/ecell4/core/ParticleSpaceRTreeImpl.hpp
@@ -100,7 +100,7 @@ public:
     // PeriodicRTree. So it overwrites the default implementation.
     std::vector<Species> list_species() const override;
 
-    std::pair<ParticleID, Particle> get_particle(const ParticleID& pid) const
+    std::pair<ParticleID, Particle> get_particle(const ParticleID& pid) const override
     {
         if(!rtree_.has(pid))
         {
@@ -113,7 +113,7 @@ public:
     }
 
     // returns true if it adds a new particle
-    bool update_particle(const ParticleID& pid, const Particle& newp)
+    bool update_particle(const ParticleID& pid, const Particle& newp) override
     {
         if(rtree_.has(pid))
         {
@@ -135,11 +135,11 @@ public:
         assert(this->diagnosis());
         return retval;
     }
-    bool has_particle(const ParticleID& pid) const
+    bool has_particle(const ParticleID& pid) const override
     {
         return rtree_.has(pid);
     }
-    void remove_particle(const ParticleID& pid)
+    void remove_particle(const ParticleID& pid) override
     {
         if(!rtree_.has(pid))
         {
@@ -154,24 +154,24 @@ public:
         return;
     }
 
-    Integer num_particles() const
+    Integer num_particles() const override
     {
         return rtree_.size();
     }
-    Integer num_particles      (const Species& sp) const;
-    Integer num_particles_exact(const Species& sp) const;
-    Integer num_molecules      (const Species& sp) const;
-    Integer num_molecules_exact(const Species& sp) const;
+    Integer num_particles      (const Species& sp) const override;
+    Integer num_particles_exact(const Species& sp) const override;
+    Integer num_molecules      (const Species& sp) const override;
+    Integer num_molecules_exact(const Species& sp) const override;
 
     std::vector<std::pair<ParticleID, Particle> >
-    list_particles() const
+    list_particles() const override
     {
         return rtree_.list_objects();
     }
     std::vector<std::pair<ParticleID, Particle> >
-    list_particles(const Species& sp) const;
+    list_particles(const Species& sp) const override;
     std::vector<std::pair<ParticleID, Particle> >
-    list_particles_exact(const Species& sp) const;
+    list_particles_exact(const Species& sp) const override;
 
     virtual void save(const std::string& filename) const
     {
@@ -180,27 +180,27 @@ public:
     }
 
 #ifdef WITH_HDF5
-    void save_hdf5(H5::Group* root) const
+    void save_hdf5(H5::Group* root) const override
     {
         save_particle_space(*this, root);
     }
 
-    void load_hdf5(const H5::Group& root)
+    void load_hdf5(const H5::Group& root) override
     {
         load_particle_space(root, this);
     }
 #endif
 
     std::vector<std::pair<std::pair<ParticleID, Particle>, Real>>
-    list_particles_within_radius(const Real3& pos, const Real& radius) const;
+    list_particles_within_radius(const Real3& pos, const Real& radius) const override;
 
     std::vector<std::pair<std::pair<ParticleID, Particle>, Real>>
     list_particles_within_radius(const Real3& pos, const Real& radius,
-            const ParticleID& ignore) const;
+            const ParticleID& ignore) const override;
 
     std::vector<std::pair<std::pair<ParticleID, Particle>, Real>>
     list_particles_within_radius(const Real3& pos, const Real& radius,
-            const ParticleID& ignore1, const ParticleID& ignore2) const;
+            const ParticleID& ignore1, const ParticleID& ignore2) const override;
 
     bool diagnosis() const
     {

--- a/ecell4/core/tests/CompartmentSpace_test.cpp
+++ b/ecell4/core/tests/CompartmentSpace_test.cpp
@@ -7,8 +7,6 @@
 #   include <boost/test/included/unit_test.hpp>
 #endif
 
-#include <boost/test/test_case_template.hpp>
-
 // #include "../types.hpp"
 // #include "../CompartmentSpace.hpp"
 #include <ecell4/core/types.hpp>

--- a/ecell4/core/tests/EventScheduler_test.cpp
+++ b/ecell4/core/tests/EventScheduler_test.cpp
@@ -7,7 +7,7 @@
 #   include <boost/test/included/unit_test.hpp>
 #endif
 
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <ecell4/core/EventScheduler.hpp>
 

--- a/ecell4/core/tests/LatticeSpace_test.cpp
+++ b/ecell4/core/tests/LatticeSpace_test.cpp
@@ -7,7 +7,7 @@
 #include <boost/test/included/unit_test.hpp>
 #endif
 
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <ecell4/core/LatticeSpaceVectorImpl.hpp>
 #include <ecell4/core/MoleculePool.hpp>

--- a/ecell4/core/tests/OffLatticeSpace_test.cpp
+++ b/ecell4/core/tests/OffLatticeSpace_test.cpp
@@ -7,7 +7,7 @@
 #include <boost/test/included/unit_test.hpp>
 #endif
 
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <ecell4/core/OffLatticeSpace.hpp>
 #include <ecell4/core/SerialIDGenerator.hpp>

--- a/ecell4/core/tests/ParticleSpaceRTreeImpl_test.cpp
+++ b/ecell4/core/tests/ParticleSpaceRTreeImpl_test.cpp
@@ -7,7 +7,7 @@
 #   include <boost/test/included/unit_test.hpp>
 #endif
 
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <ecell4/core/ParticleSpaceRTreeImpl.hpp>
 #include <ecell4/core/SerialIDGenerator.hpp>

--- a/ecell4/core/tests/ParticleSpace_test.cpp
+++ b/ecell4/core/tests/ParticleSpace_test.cpp
@@ -7,7 +7,7 @@
 #   include <boost/test/included/unit_test.hpp>
 #endif
 
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <ecell4/core/ParticleSpaceCellListImpl.hpp>
 #include <ecell4/core/SerialIDGenerator.hpp>

--- a/ecell4/core/tests/PeriodicRTree_test.cpp
+++ b/ecell4/core/tests/PeriodicRTree_test.cpp
@@ -8,7 +8,7 @@
 #endif
 
 
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 // Some of the CI environments uses relatively old version of Boost.
 // std::tuple can be used with Boost 1.68.0+.

--- a/ecell4/core/tests/ReactionRule_test.cpp
+++ b/ecell4/core/tests/ReactionRule_test.cpp
@@ -7,7 +7,7 @@
 #   include <boost/test/included/unit_test.hpp>
 #endif
 
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <ecell4/core/Species.hpp>
 #include <ecell4/core/Context.hpp>

--- a/ecell4/core/tests/Shape_test.cpp
+++ b/ecell4/core/tests/Shape_test.cpp
@@ -7,7 +7,7 @@
 #   include <boost/test/included/unit_test.hpp>
 #endif
 
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include <ecell4/core/Sphere.hpp>
 #include <ecell4/core/Rod.hpp>

--- a/ecell4/core/tests/SubvolumeSpace_test.cpp
+++ b/ecell4/core/tests/SubvolumeSpace_test.cpp
@@ -7,8 +7,6 @@
 #   include <boost/test/included/unit_test.hpp>
 #endif
 
-#include <boost/test/test_case_template.hpp>
-
 #include <ecell4/core/types.hpp>
 #include <ecell4/core/SubvolumeSpace.hpp>
 

--- a/ecell4/sgfrd/SGFRDFactory.hpp
+++ b/ecell4/sgfrd/SGFRDFactory.hpp
@@ -93,7 +93,7 @@ class SGFRDFactory :
 
   protected:
 
-    virtual world_type* create_world(const Real3& edge_lengths) const
+    virtual world_type* create_world(const Real3& edge_lengths) const override
     {
         if (rng_)
         {
@@ -132,7 +132,7 @@ class SGFRDFactory :
     }
 
     virtual simulator_type* create_simulator(
-        const std::shared_ptr<world_type>& w, const std::shared_ptr<Model>& m) const
+        const std::shared_ptr<world_type>& w, const std::shared_ptr<Model>& m) const override
     {
         return new simulator_type(w, m, bd_dt_factor_, bd_reaction_length_factor_);
     }

--- a/ecell4/sgfrd/SGFRDSimulator.hpp
+++ b/ecell4/sgfrd/SGFRDSimulator.hpp
@@ -279,7 +279,7 @@ class SGFRDSimulator :
     Real dt() const override {return dt_;}
     Real reaction_length() const {return reaction_length_;}
 
-    bool check_reaction() const {return last_reactions_.size() > 0;}
+    bool check_reaction() const override {return last_reactions_.size() > 0;}
     std::vector<std::pair<ReactionRule, reaction_info_type> > const&
     last_reactions() const {return last_reactions_;}
 

--- a/ecell4/sgfrd/SGFRDWorld.hpp
+++ b/ecell4/sgfrd/SGFRDWorld.hpp
@@ -296,7 +296,7 @@ class SGFRDWorld
         return false;
     }
 
-    std::vector<Species> list_species() const
+    std::vector<Species> list_species() const override
     {
         return ps_->list_species();
     }

--- a/ecell4/spatiocyte/tests/OneToManyMap_test.cpp
+++ b/ecell4/spatiocyte/tests/OneToManyMap_test.cpp
@@ -7,7 +7,7 @@
 #   include <boost/test/included/unit_test.hpp>
 #endif
 
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include "../OneToManyMap.hpp"
 

--- a/ecell4/spatiocyte/tests/SpatiocyteSimulator_test.cpp
+++ b/ecell4/spatiocyte/tests/SpatiocyteSimulator_test.cpp
@@ -7,7 +7,7 @@
 #include <boost/test/included/unit_test.hpp>
 #endif
 
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include "../SpatiocyteSimulator.hpp"
 #include <ecell4/core/NetworkModel.hpp>

--- a/ecell4/spatiocyte/tests/SpatiocyteWorld_test.cpp
+++ b/ecell4/spatiocyte/tests/SpatiocyteWorld_test.cpp
@@ -7,7 +7,7 @@
 #include <boost/test/included/unit_test.hpp>
 #endif
 
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 
 #include "../OffLattice.hpp"
 #include "../SpatiocyteWorld.hpp"


### PR DESCRIPTION
- remove deprecated boost.test headers
  - `#include <boost/test/test_case_template.hpp>`
  - `#include <boost/test/floating_point_comparison.hpp>`
- add missing `override` specifiers
- add paren to `while(ctx = next())` to make sure that `ctx` is the condition