### PR TITLE
:arrow_up: update pybind11 from 2.3.0 to 2.6.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,8 @@ jobs:
   - script: echo hello from macOS 10.15
   - bash: |
       git submodule init && git submodule update
-      brew update && brew install boost gsl hdf5 cmake python
+      brew update
+      brew install boost gsl hdf5@1.10 cmake python
       /usr/local/bin/python3 setup.py install
       /usr/local/bin/python3 setup.py test
 - job: macOS1014

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,7 @@ jobs:
       git submodule init && git submodule update
       brew update
       brew install boost gsl hdf5@1.10 cmake python
+      export PATH="/usr/local/opt/hdf5@1.10/bin:${PATH}"
       /usr/local/bin/python3 setup.py install
       /usr/local/bin/python3 setup.py test
 - job: macOS1014
@@ -40,6 +41,8 @@ jobs:
   - script: echo hello from macOS 10.14
   - bash: |
       git submodule init && git submodule update
-      brew update && brew install boost gsl hdf5 cmake python
+      brew update
+      brew install boost gsl hdf5 cmake python
+      export PATH="/usr/local/opt/hdf5@1.10/bin:${PATH}"
       /usr/local/bin/python3 setup.py install
       /usr/local/bin/python3 setup.py test


### PR DESCRIPTION
There seems to be a problem in cpython 3.9.0 that causes UB. To workaround it, we need to update pybind11 to 2.6.0, or just wait until 3.9.1.