### PR TITLE
:heavy_minus_sign: drop python 3.5 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     parameters:
       pyver:
         type: enum
-        enum: ["cp35-cp35m", "cp36-cp36m", "cp37-cp37m", "cp38-cp38"]
+        enum: ["cp36-cp36m", "cp37-cp37m", "cp38-cp38"]
     steps:
       - setup_remote_docker
       - checkout
@@ -46,9 +46,6 @@ workflows:
   version: 2
   build_wheels:
     jobs:
-      - build:
-          name: build_py35
-          pyver: cp35-cp35m
       - build:
           name: build_py36
           pyver: cp36-cp36m


### PR DESCRIPTION
It is no longer supported.

https://pythoninsider.blogspot.com/2020/10/python-35-is-no-longer-supported.html?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+PythonInsider+%28Python+Insider%29